### PR TITLE
Add GitHub action to lint shell scripts

### DIFF
--- a/.github/workflows/check-shell.yml
+++ b/.github/workflows/check-shell.yml
@@ -1,0 +1,12 @@
+name: Lint scripts
+on: [push, pull_request]
+jobs:
+  check_shell:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+      - name: Lint shell scripts (shellcheck)
+        uses: ludeeus/action-shellcheck@master
+        with:
+          ignore: Vagrantfile


### PR DESCRIPTION
This adds a workflow to lint all shell scripts (apart from the non-standard `Vagrantfile`) with https://github.com/marketplace/actions/shellcheck.