### PR TITLE
Add GitHub action for vagrant up

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
     types: [ready_for_review]
 jobs:
   vagrant-up:
-    runs-on: ubuntu-latest
+    runs-on: macos-10.15
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,13 @@ jobs:
     - name: Run vagrant up
       run: vagrant up
 
-    - name: ssh into box after boot
-      run: vagrant ssh -c "echo 'hello world!'"
+    - name: Package Vagrant box
+      run: vagrant package --base "preCICE-VM" --output preCICE.box
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v2
+      with:
+          name: precice-vagrant-box
+          path: |
+            preCICE.box
         

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,9 @@ jobs:
     - name: Package Vagrant box
       run: vagrant package --base "preCICE-VM" --output preCICE.box
 
+    - name: Generate Vagrant box hash
+      run: sha256sum preCICE.box
+
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,6 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
           name: precice-vagrant-box
-          path: |
-            preCICE.box
+          path: preCICE.box
+          retention-days: 7
         

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build (provision)
+name: Build and package
 on:
   pull_request:
     types: [ready_for_review]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,27 @@
+name: Build (provision)
+on:
+  pull_request:
+    types: [ready_for_review]
+jobs:
+  vagrant-up:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Cache Vagrant boxes
+      uses: actions/cache@v2
+      with:
+        path: ~/.vagrant.d/boxes
+        key: ${{ runner.os }}-vagrant-${{ hashFiles('Vagrantfile') }}
+        restore-keys: |
+          ${{ runner.os }}-vagrant-
+    - name: Show Vagrant version
+      run: vagrant --version
+
+    - name: Run vagrant up
+      run: vagrant up
+
+    - name: ssh into box after boot
+      run: vagrant ssh -c "echo 'hello world!'"
+        

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,9 +17,6 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-vagrant-
 
-    - name: Generate Vagrantfile SHA256 hash
-      run: shasum -a 256 Vagrantfile
-
     - name: Show Vagrant version
       run: vagrant --version
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,8 +17,8 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-vagrant-
 
-    - name: Generate Vagrantfile MD5 hash
-      run: md5sum Vagrantfile
+    - name: Generate Vagrantfile SHA256 hash
+      run: shasum -a 256 Vagrantfile
 
     - name: Show Vagrant version
       run: vagrant --version
@@ -29,8 +29,8 @@ jobs:
     - name: Package Vagrant box
       run: vagrant package --base "preCICE-VM" --output preCICE.box
 
-    - name: Generate Vagrant box MD5 hash
-      run: md5sum preCICE.box
+    - name: Generate Vagrant box SHA256 hash
+      run: shasum -a 256 preCICE.box
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,10 @@ jobs:
         key: ${{ runner.os }}-vagrant-${{ hashFiles('Vagrantfile') }}
         restore-keys: |
           ${{ runner.os }}-vagrant-
+
+    - name: Generate Vagrantfile MD5 hash
+      run: md5sum Vagrantfile
+
     - name: Show Vagrant version
       run: vagrant --version
 
@@ -25,8 +29,8 @@ jobs:
     - name: Package Vagrant box
       run: vagrant package --base "preCICE-VM" --output preCICE.box
 
-    - name: Generate Vagrant box hash
-      run: sha256sum preCICE.box
+    - name: Generate Vagrant box MD5 hash
+      run: md5sum preCICE.box
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v2

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -50,7 +50,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision "file", source: "provisioning/get-started.desktop", destination: "~/Desktop/get-started.desktop"
 
   # Pre-packaging steps
-  # config.vm.provision "shell", path: "provisioning/cleanup.sh", privileged: false
+  config.vm.provision "shell", path: "provisioning/cleanup.sh", privileged: false
   # Add the default Vagrant insecure public key to the authorized keys
   config.vm.provision "file", source: "provisioning/vagrant.pub", destination: "~/.ssh/vagrant.pub"
   config.vm.provision "shell", inline: <<-SHELL

--- a/provisioning/cleanup.sh
+++ b/provisioning/cleanup.sh
@@ -5,4 +5,4 @@ set -ex
 sudo apt-get clean
 
 # Cleanup all object files from compilation
-find /home/vagrant/ -type f -name '*.o' -exec rm -fv {} \;
+find ${HOME} -type f -name '*.o' -exec rm -fv {} \;

--- a/provisioning/cleanup.sh
+++ b/provisioning/cleanup.sh
@@ -5,4 +5,4 @@ set -ex
 sudo apt-get clean
 
 # Cleanup all object files from compilation
-find ${HOME} -type f -name '*.o' -exec rm -fv {} \;
+find "${HOME}" -type f -name '*.o' -exec rm -fv {} \;

--- a/provisioning/install-calculix.sh
+++ b/provisioning/install-calculix.sh
@@ -7,6 +7,7 @@ sudo apt-get install -y libarpack2-dev libspooles-dev libyaml-cpp-dev
 # Install CalculiX
 wget --quiet http://www.dhondt.de/ccx_2.16.src.tar.bz2
 tar xvjf ccx_2.16.src.tar.bz2
+rm -fv ccx_2.16.src.tar.bz2
 
 # Get the CalculiX-preCICE adapter
 if [ ! -d "calculix-adapter/" ]; then

--- a/provisioning/install-calculix.sh
+++ b/provisioning/install-calculix.sh
@@ -20,4 +20,4 @@ fi
 )
 
 # Add the CalculiX adapter to PATH
-echo "export PATH=\"~/calculix-adapter/bin:\${PATH}\"" >>~/.bashrc
+echo "export PATH=\"\${HOME}/calculix-adapter/bin:\${PATH}\"" >>~/.bashrc

--- a/provisioning/install-config-visualizer.sh
+++ b/provisioning/install-config-visualizer.sh
@@ -8,7 +8,7 @@ fi
 pip3 install --user -e config-visualizer
 
 # Add the config-visualizer to PATH
-echo "export PATH=\"~/config-visualizer/bin:\${PATH}\"" >>~/.bashrc
+echo "export PATH=\"\${HOME}/config-visualizer/bin:\${PATH}\"" >>~/.bashrc
 
 # By default, there is no `python` executable, there is only `python3`,
 # which causes issues to the config-visualizer

--- a/provisioning/install-dealii.sh
+++ b/provisioning/install-dealii.sh
@@ -17,4 +17,4 @@ fi
 )
 
 # Add the deal.II adapter to PATH
-echo "export PATH=\"~/dealii-adapter:\${PATH}\"" >>~/.bashrc
+echo "export PATH=\"\${HOME}/dealii-adapter:\${PATH}\"" >>~/.bashrc

--- a/provisioning/install-openfoam.sh
+++ b/provisioning/install-openfoam.sh
@@ -6,10 +6,8 @@ wget -q -O - https://dl.openfoam.com/add-debian-repo.sh | sudo bash
 
 # Install OpenFOAM v2012:
 sudo apt-get install -y openfoam2012-dev
-# Enable OpenFOAM by default and apply now:
+# Enable OpenFOAM by default:
 echo ". /usr/lib/openfoam/openfoam2012/etc/bashrc" >> ~/.bashrc
-# shellcheck source=/dev/null
-. /usr/lib/openfoam/openfoam2012/etc/bashrc
 
 # Get the OpenFOAM-preCICE adapter
 if [ ! -d "openfoam-adapter/" ]; then
@@ -18,5 +16,5 @@ fi
 (
     cd openfoam-adapter
     git pull
-    ./Allwmake
+    openfoam2012 ./Allwmake
 )

--- a/provisioning/install-openfoam.sh
+++ b/provisioning/install-openfoam.sh
@@ -9,7 +9,7 @@ sudo apt-get install -y openfoam2012-dev
 # Enable OpenFOAM by default and apply now:
 echo ". /usr/lib/openfoam/openfoam2012/etc/bashrc" >> ~/.bashrc
 # shellcheck source=/dev/null
-# . /usr/lib/openfoam/openfoam2012/etc/bashrc
+. /usr/lib/openfoam/openfoam2012/etc/bashrc
 
 # Get the OpenFOAM-preCICE adapter
 if [ ! -d "openfoam-adapter/" ]; then

--- a/provisioning/install-paraview.sh
+++ b/provisioning/install-paraview.sh
@@ -7,5 +7,5 @@ if [ ! -d "paraview" ]; then
     wget --no-check-certificate --quiet -O - "${PARAVIEW_URL}" | tar -xz -C paraview
     ln -sf ~/paraview/ParaView-5.8.1-MPI-Linux-Python3.7-64bit/bin/paraview ~/Desktop/
     # Add ParaView to PATH
-    echo "export PATH=\"~/paraview/ParaView-5.8.1-MPI-Linux-Python3.7-64bit/bin:\${PATH}\"" >>~/.bashrc
+    echo "export PATH=\"\${HOME}/paraview/ParaView-5.8.1-MPI-Linux-Python3.7-64bit/bin:\${PATH}\"" >>~/.bashrc
 fi

--- a/provisioning/install-su2.sh
+++ b/provisioning/install-su2.sh
@@ -2,7 +2,9 @@
 set -ex
 
 # Get SU2 6.0.0 from GitHub
-wget --quiet https://github.com/su2code/SU2/archive/v6.0.0.tar.gz && tar -xzf v6.0.0.tar.gz
+wget --quiet https://github.com/su2code/SU2/archive/v6.0.0.tar.gz
+tar -xzf v6.0.0.tar.gz
+rm -fv v6.0.0.tar.gz
 
 # Add SU2 to PATH and apply.
 # We first export to a separate script, so that we can load it here (non-interactive shell).

--- a/provisioning/install-su2.sh
+++ b/provisioning/install-su2.sh
@@ -9,13 +9,13 @@ rm -fv v6.0.0.tar.gz
 # Add SU2 to PATH and apply.
 # We first export to a separate script, so that we can load it here (non-interactive shell).
 {
-    echo "export SU2_HOME=\"/home/vagrant/SU2-6.0.0\""
+    echo "export SU2_HOME=\"\${HOME}/SU2-6.0.0\""
     echo "export SU2_RUN=\"\${SU2_HOME}/SU2_CFD/bin\""
     echo "export PATH=\"\${SU2_RUN}:\${PATH}\""
     echo "export PYTHONPATH=\"\${SU2_RUN}:\${PYTHONPATH}\""
 } >> ~/.su2-bashrc
 
-echo ". ~/.su2-bashrc" >> ~/.bashrc
+echo ". \${HOME}/.su2-bashrc" >> ~/.bashrc
 # shellcheck source=/dev/null
 . ~/.su2-bashrc
 


### PR DESCRIPTION
This adds a GitHub Actions workflow to provision the box (run `vagrant up`), as described in https://github.com/jonashackt/vagrant-github-actions The goal is to check building from a clean state, as usually I try to re-provision while developing. This already helped me find an issue with OpenFOAM that I had not noticed before for this very reason.

Unfortunately, [nested virtualization](https://github.com/actions/virtual-environments/issues/183) is not supported in Linux runners, only on macOS runners. I am using the currently latest "stable" image `macos-10.15`.

This also packages the box and uploads it to the artifacts, retaining it for 7 days. The artifact is expected to be ~4-5GB.

Publishing is not covered here: Would be additional work to setup right now, while I prefer doing releases when I feel this is needed. The labor hurdle for publishing once in a while is not really significant here.

This workflow should [run only when a PR is marked as "ready for review"](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request), to save resources, as each job should take a long time (~1h).  The [time limits](https://docs.github.com/en/actions/reference/usage-limits-billing-and-administration) seem to be enough (6h/job).

Additional side-fixes:

- Enables cleanup by default again, as we now also package the box.
- Cleanup the downloaded solver archives after they have been extracted.
- Replace `~` with `${HOME}` in environment variables for portability: the run scripts, for example, do not understand `~`.
- Use the `openfoam2012` session instead of loading the OpenFOAM bashrc file: it was causing strange unrelated errors, probably due to shell incompatibilities.