### PR TITLE
Disable screensaver and screen lock

### DIFF
--- a/provisioning/post-install.sh
+++ b/provisioning/post-install.sh
@@ -3,3 +3,9 @@ set -ex
 
 # Create a link to the default shared folder
 ln -sf /vagrant/ ~/Desktop/shared
+
+# Disable the screensaver and automatic screen lock
+{
+    echo "xset s off -dpms"
+    echo "gsettings set org.gnome.desktop.screensaver lock-enabled false"
+} >> ~/.bashrc


### PR DESCRIPTION
Closes #14 by setting (in the `~/.bashrc`, maybe there is an even better place):

```shell
xset s off -dpms
gsettings set org.gnome.desktop.screensaver lock-enabled false
```