### PR TITLE
Enable multiple download tries in apt

### DIFF
--- a/provisioning/install-basics.sh
+++ b/provisioning/install-basics.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ex
 
-# Some repos are a bit fragile and needs multiple download tries
+# Some repos are a bit fragile and need multiple download tries
 echo 'APT::Acquire::Retries "4";' | sudo tee /etc/apt/apt.conf.d/80-retries
 
 # We (may) need the multiverse repository for the VBox Guest Additions

--- a/provisioning/install-basics.sh
+++ b/provisioning/install-basics.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -ex
 
+# Some repos are a bit fragile and needs multiple download tries
+echo 'APT::Acquire::Retries "4";' | sudo tee /etc/apt/apt.conf.d/80-retries
+
 # We (may) need the multiverse repository for the VBox Guest Additions
 sudo apt-add-repository multiverse
 sudo apt-get update


### PR DESCRIPTION
This prevents the OpenFOAM installation from failing.