### PR TITLE
Add DUNE

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ This box is based on the [bento/ubuntu-20.04](https://github.com/chef/bento/blob
 - Nutils latest from PIP
 - SU2 6.0.0 and the SU2-preCICE adapter (master)
 - code_aster 14.6 and the code_aster-preCICE adapter (master)
+- DUNE 2.8 and the experimental DUNE-preCICE adapter (master)
 - Paraview from the official binaries
 - Gnuplot
 

--- a/provisioning/install-dune.sh
+++ b/provisioning/install-dune.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -ex
+
+# Install DUNE
+wget --quiet https://www.dune-project.org/download/2.8.0/dune-common-2.8.0.tar.gz
+tar xvzf dune-common-2.8.0.tar.gz
+rm -fv dune-common-2.8.0.tar.gz
+(
+    cd dune-common-2.8.0
+    ./bin/dunecontrol all
+)
+
+# Add DUNE to PATH and apply.
+# We first export to a separate script, so that we can load it here (non-interactive shell).
+{
+    echo "export PATH=\"\${HOME}/dune-common-2.8.0/bin:\${PATH}\""
+} >> ~/.dune-bashrc
+
+echo ". \${HOME}/.dune-bashrc" >> ~/.bashrc
+# shellcheck source=/dev/null
+. ~/.dune-bashrc
+
+# Get the DUNE-preCICE adapter
+if [ ! -d "dune-adapter/" ]; then
+    git clone --depth=1 --branch main --depth=1 https://github.com/precice/dune-adapter.git
+fi
+(
+    cd dune-adapter/dune-precice
+    git pull
+    # Build the DUNE-preCICE adapter
+    ../../dune-common-2.8.0/bin/dunecontrol --current all
+)
+
+# Add the DUNE adapter to PATH
+echo "export PATH=\"\${HOME}/dune-adapter/dune-precice/bin:\${PATH}\"" >> ~/.bashrc


### PR DESCRIPTION
This adds DUNE 2.8 (built from source) and the experimental DUNE adapter.

I am currently stuck at making DUNE discoverable at runtime. I am already exposing the `bin/` directory via `PATH`, but apparently, it needs more than that.

As an alternative solution, DUNE 2.6 is available from APT, but the adapter seems to require DUNE >= 2.7. I assume that this is not a strict requirement and if I reduce it to 2.6, the adapter build successfully.

closes #27