### PR TITLE
Rename config-visualizer-* aliases

### DIFF
--- a/provisioning/.alias
+++ b/provisioning/.alias
@@ -1,12 +1,12 @@
 # preCICE config visualizer
-function config-visualizer-pdf(){
-  cat $1 | precice-config-visualizer | dot -Tpdf > precice-config.pdf
+function preciceToPNG(){
+  cat "${1:-precice-config.xml}" | precice-config-visualizer | dot -Tpng > precice-config.png
 }
 
-function config-visualizer-svg(){
-  cat $1 | precice-config-visualizer | dot -Tsvg > precice-config.svg
+function preciceToPDF(){
+  cat "${1:-precice-config.xml}" | precice-config-visualizer | dot -Tpdf > precice-config.pdf
 }
 
-function config-visualizer(){
-  cat $1 | precice-config-visualizer | dot -Tpng > precice-config.png
+function preciceToSVG(){
+  cat "${1:-precice-config.xml}" | precice-config-visualizer | dot -Tsvg > precice-config.svg
 }


### PR DESCRIPTION
This replaces the `config-visualizer`, `config-visualizer-pdf`, and `config-visualizer-svg` aliases with the OpenFOAM-inspired:
- preciceToPNG
- preciceToPDF
- preciceToSVG

They take one optional argument for the config file, which defaults to `precice-config.xml`.

@uekerman if you agree with the names, I will merge and update the website.

Closes #35