### PR TITLE
Add IPython as nicer Python environment

### DIFF
--- a/provisioning/install-devel.sh
+++ b/provisioning/install-devel.sh
@@ -4,3 +4,5 @@ set -ex
 sudo apt-get install -y build-essential git cmake cmake-curses-gui
 
 sudo apt-get install -y nano vim gedit
+
+sudo apt-get install -y ipython3


### PR DESCRIPTION
@carlosal1015 suggested that we also add [Jupyter](https://ipython.org/) (just the command line, not the full Notebooks environment) to get suggestions when writing Python code.

@BenjaminRodenberg or @IshaanDesai approve if you think this is a good idea. If you want to recommend more Python-related tools that would be useful in the VM (but not very large to install), this would be great!