### PR TITLE
Update main, v202202.0.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
     
 jobs:
   vagrant-up:
-    runs-on: macos-latest
+    runs-on: macos-12
 
     strategy:
       fail-fast: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,13 @@ jobs:
   vagrant-up:
     runs-on: macos-10.15
 
+    strategy:
+      fail-fast: true
+      matrix:
+        provider: [virtualbox] # Add libvirt once available
+
+    name: Build Vagrant Box for ${{ matrix.provider }}
+
     steps:
     - uses: actions/checkout@v2
       with:
@@ -21,11 +28,21 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-vagrant-
 
+    - name: Install libvirt
+      if: matrix.provider == 'libvirt'
+      run: |
+        # Install libvirt etc
+        echo "libvirt is currently not supported"
+        exit 1
+        # Install vagrant plugin
+        # vagrant plugin install vagrant-libvirt
+
     - name: Show Vagrant version
       run: vagrant --version
 
     - name: Run vagrant up
-      run: vagrant up
+      run: |
+        vagrant up --provider=${{ matrix.provider }}
 
     - name: Package Vagrant box
       run: vagrant package --base "preCICE-VM" --output preCICE.box
@@ -36,7 +53,7 @@ jobs:
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
-          name: precice-vagrant-box
+          name: precice-vagrant-box-${{ matrix.provider }}
           path: preCICE.box
           retention-days: 7
         

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
     
 jobs:
   vagrant-up:
-    runs-on: macos-10.15
+    runs-on: macos-latest
 
     strategy:
       fail-fast: true

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ A few things you may need:
 
 ## What is included?
 
-This box is based on the [bento/ubuntu-20.04](https://github.com/chef/bento/blob/master/packer_templates/ubuntu/ubuntu-20.04-amd64.json) base box and installs:
+This box is based on the [generic/ubuntu2004](https://github.com/lavabit/robox/tree/master/scripts/ubuntu2004) base box and installs:
 
 - Xubuntu-core (Xfce desktop environment) and related tools
 - VirtualBox guest additions
@@ -108,4 +108,15 @@ Afterwards, you probably want to destroy everything to save storage space:
 ```bash
 vagrant destroy
 vagrant box remove test-box
+```
+
+## KVM support
+
+If you require a more responsive experience, lower overhead, or exotic features such as GPU pass through, then the `libvirt` vagrant box is for you.
+This allows you to run the vagrant box via libvirt and QEMU as a Kernerl Virtual Machine (KVM).
+
+To use this box, first install the vagrant plugin `vagrant-libvirt` following the [official installation instructions](https://github.com/vagrant-libvirt/vagrant-libvirt#installation).
+Then you follow the normal usage instructions above, but you need to tell vagrant to use the `libvirt` box by passing one additional option:
+```
+vagrant up --provider=libvirt
 ```

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,8 +2,9 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-  # The Vagrant documentation recommends the bento images instead of ubuntu (more providers, open source)
-  config.vm.box = "bento/ubuntu-20.04"
+  # The generic/ images support virtualbox as well as libvirt and hyperv.
+  # This allows us to create performance oriented images for Linux (libvirt) and Windows (hyperv).
+  config.vm.box = "generic/ubuntu2004"
 
   # We don't want the box to automatically update every time it starts.
   # We can instead handle updates internally, without destroying the machine.
@@ -23,6 +24,14 @@ Vagrant.configure("2") do |config|
     # The default graphics controller is VboxSVGA. This seems to cause issues with auto-scaling.
     # VMSVGA seems to work better.
     vb.customize ["modifyvm", :id, "--graphicscontroller", "vmsvga"]
+  end
+
+  # The libvirt provider needs to be installed using "vagrant plugin install vagrant-libvirt"
+  config.vm.provider :libvirt do |lv|
+    lv.forward_ssh_port = true
+    lv.title = "preCICE-VM"
+    lv.cpus = 2
+    lv.memory = 2048
   end
 
   # Install a desktop environment and basic tools

--- a/provisioning/install-basics.sh
+++ b/provisioning/install-basics.sh
@@ -14,7 +14,8 @@ sudo apt-get install -y xubuntu-core^
 sudo apt-get install -y thunar xfce4-terminal terminator bash-completion tree evince firefox firefox-locale-en baobab catfish
 
 # Setup auto-login for the graphical session
-echo "autologin-user=vagrant" | sudo tee --append /usr/share/lightdm/lightdm.conf.d/60-xubuntu.conf
+# Disabled due to https://github.com/precice/vm/issues/40
+# echo "autologin-user=vagrant" | sudo tee --append /usr/share/lightdm/lightdm.conf.d/60-xubuntu.conf
 
 # Install the VirtualBox guest additions
 sudo apt-get install -y virtualbox-guest-dkms virtualbox-guest-utils virtualbox-guest-x11

--- a/provisioning/install-precice.sh
+++ b/provisioning/install-precice.sh
@@ -59,6 +59,6 @@ pip3 install --user pyprecice
 if [ ! -d "python-bindings/" ]; then
     git clone --depth=1 --branch master https://github.com/precice/python-bindings.git
 fi
-cp -r python-bindings/solverdummy/ precice-examples/solverdummies/python/
+cp -r python-bindings/examples/solverdummy/ precice-examples/solverdummies/python/
 rm -r python-bindings
 ###


### PR DESCRIPTION
Same as [202202.0.1](https://app.vagrantup.com/precice/boxes/precice-vm/versions/202202.0.1), with fixed #40 (disabled auto-login) and preCICE v2.4.0.

Also includes support for libvirt (#25) and updates the macOS GitHub Actions runner to the latest version (reminder: we need macOS because that's the only available runner that supports virtualization, maybe this has changed in the meantime).