### PR TITLE
Upgrade OpenFOAM to v2206

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -46,7 +46,7 @@ Vagrant.configure("2") do |config|
   # Install solvers, adapters, and related tools
   config.vm.provision "shell", path: "provisioning/install-config-visualizer.sh", privileged: false
   config.vm.provision "shell", path: "provisioning/install-openfoam.sh", privileged: false
-  config.vm.provision "file", source: "provisioning/prebuilt/swak4Foam/swak4Foam.tar.gz", destination: "~/OpenFOAM/vagrant-v2112/platforms/linux64GccDPInt32Opt/swak4Foam.tar.gz"
+  config.vm.provision "file", source: "provisioning/prebuilt/swak4Foam/swak4Foam.tar.gz", destination: "~/OpenFOAM/vagrant-v2206/platforms/linux64GccDPInt32Opt/swak4Foam.tar.gz"
   config.vm.provision "shell", path: "provisioning/install-dealii.sh", privileged: false
   config.vm.provision "shell", path: "provisioning/install-calculix.sh", privileged: false
   config.vm.provision "shell", path: "provisioning/install-fenics.sh", privileged: false

--- a/provisioning/install-basics.sh
+++ b/provisioning/install-basics.sh
@@ -18,7 +18,7 @@ sudo apt-get install -y thunar xfce4-terminal terminator bash-completion tree ev
 # echo "autologin-user=vagrant" | sudo tee --append /usr/share/lightdm/lightdm.conf.d/60-xubuntu.conf
 
 # Install the VirtualBox guest additions
-sudo apt-get install -y virtualbox-guest-dkms virtualbox-guest-utils virtualbox-guest-x11
+sudo apt-get install -y virtualbox-dkms virtualbox-guest-utils virtualbox-guest-x11
 
 # Create Desktop
 mkdir -p ~/Desktop

--- a/provisioning/install-basics.sh
+++ b/provisioning/install-basics.sh
@@ -18,7 +18,7 @@ sudo apt-get install -y thunar xfce4-terminal terminator bash-completion tree ev
 # echo "autologin-user=vagrant" | sudo tee --append /usr/share/lightdm/lightdm.conf.d/60-xubuntu.conf
 
 # Install the VirtualBox guest additions
-sudo apt-get install -y virtualbox-dkms virtualbox-guest-utils virtualbox-guest-x11
+sudo apt-get install -y virtualbox-guest-dkms virtualbox-guest-utils virtualbox-guest-x11
 
 # Create Desktop
 mkdir -p ~/Desktop

--- a/provisioning/install-openfoam.sh
+++ b/provisioning/install-openfoam.sh
@@ -4,10 +4,10 @@ set -ex
 # Add the signing key, add the repository, update:
 wget -q -O - https://dl.openfoam.com/add-debian-repo.sh | sudo bash
 
-# Install OpenFOAM v2112:
-sudo apt-get install -y openfoam2112-dev
+# Install OpenFOAM v2206:
+sudo apt-get install -y openfoam2206-dev
 # Enable OpenFOAM by default:
-echo ". /usr/lib/openfoam/openfoam2112/etc/bashrc" >> ~/.bashrc
+echo ". /usr/lib/openfoam/openfoam2206/etc/bashrc" >> ~/.bashrc
 
 # Get the OpenFOAM-preCICE adapter
 if [ ! -d "openfoam-adapter/" ]; then
@@ -16,26 +16,26 @@ fi
 (
     cd openfoam-adapter
     git pull
-    openfoam2112 ./Allwmake
+    openfoam2206 ./Allwmake
 )
 
 # Get swak4Foam (provides groovyBC, needed for the turek-hron-fsi3 tutorial)
-#
-# # Option 1: Build from source
-# sudo apt-get install -y mercurial
-# hg clone http://hg.code.sf.net/p/openfoam-extend/swak4Foam swak4Foam
-# (
-#     cd swak4Foam
-#     hg checkout develop
-#     openfoam2112 ./AllwmakeAll
-# )
-#
-# # Remove some swak4Foam files to save space (approx. 150MB)
-# rm -rfv .~swak4Foam
-# sudo apt-get purge --autoremove -y mercurial # This also removes Python2, yipieh!
+
+# Option 1: Build from source
+sudo apt-get install -y mercurial
+hg clone http://hg.code.sf.net/p/openfoam-extend/swak4Foam swak4Foam
+(
+    cd swak4Foam
+    hg checkout develop
+    openfoam2206 ./AllwmakeAll
+)
+
+# Remove some swak4Foam files to save space (approx. 150MB)
+rm -rfv .~swak4Foam
+sudo apt-get purge --autoremove -y mercurial # This also removes Python2, yipieh!
 #
 # # Option 2: Use pre-built binaries
-# # (see Vagrantfile and post-install.sh, rebuild and update for OpenFOAM version other than v2112)
+# # (see Vagrantfile and post-install.sh, rebuild and update for OpenFOAM version other than v2206)
 
 # Build the tutorials partitioned-heat-conduction solver
-cd ~/tutorials/partitioned-heat-conduction/openfoam-solver && openfoam2112 wmake
+cd ~/tutorials/partitioned-heat-conduction/openfoam-solver && openfoam2206 wmake

--- a/provisioning/install-openfoam.sh
+++ b/provisioning/install-openfoam.sh
@@ -20,7 +20,7 @@ fi
 )
 
 # Get swak4Foam (provides groovyBC, needed for the turek-hron-fsi3 tutorial)
-
+#
 # # Option 1: Build from source
 # sudo apt-get install -y mercurial
 # hg clone http://hg.code.sf.net/p/openfoam-extend/swak4Foam swak4Foam
@@ -29,7 +29,7 @@ fi
 #     hg checkout develop
 #     openfoam2206 ./AllwmakeAll
 # )
-
+#
 # # Remove some swak4Foam files to save space (approx. 150MB)
 # rm -rfv .~swak4Foam
 # sudo apt-get purge --autoremove -y mercurial # This also removes Python2, yipieh!

--- a/provisioning/install-openfoam.sh
+++ b/provisioning/install-openfoam.sh
@@ -21,18 +21,18 @@ fi
 
 # Get swak4Foam (provides groovyBC, needed for the turek-hron-fsi3 tutorial)
 
-# Option 1: Build from source
-sudo apt-get install -y mercurial
-hg clone http://hg.code.sf.net/p/openfoam-extend/swak4Foam swak4Foam
-(
-    cd swak4Foam
-    hg checkout develop
-    openfoam2206 ./AllwmakeAll
-)
+# # Option 1: Build from source
+# sudo apt-get install -y mercurial
+# hg clone http://hg.code.sf.net/p/openfoam-extend/swak4Foam swak4Foam
+# (
+#     cd swak4Foam
+#     hg checkout develop
+#     openfoam2206 ./AllwmakeAll
+# )
 
-# Remove some swak4Foam files to save space (approx. 150MB)
-rm -rfv .~swak4Foam
-sudo apt-get purge --autoremove -y mercurial # This also removes Python2, yipieh!
+# # Remove some swak4Foam files to save space (approx. 150MB)
+# rm -rfv .~swak4Foam
+# sudo apt-get purge --autoremove -y mercurial # This also removes Python2, yipieh!
 #
 # # Option 2: Use pre-built binaries
 # # (see Vagrantfile and post-install.sh, rebuild and update for OpenFOAM version other than v2206)

--- a/provisioning/post-install.sh
+++ b/provisioning/post-install.sh
@@ -1,12 +1,11 @@
 #!/usr/bin/env bash
 set -ex
 
-# Upgrade to OpenFOAM v2206
-# # Setup swak4Foam
-# (
-#     cd "${HOME}/OpenFOAM/vagrant-v2112/platforms/linux64GccDPInt32Opt/"
-#     tar -xzvf swak4Foam.tar.gz
-# )
+# Setup swak4Foam
+(
+    cd "${HOME}/OpenFOAM/vagrant-v2206/platforms/linux64GccDPInt32Opt/"
+    tar -xzvf swak4Foam.tar.gz
+)
 
 # Create a link to the default shared folder
 ln -sf /vagrant/ ~/Desktop/shared

--- a/provisioning/post-install.sh
+++ b/provisioning/post-install.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 set -ex
 
-# Setup swak4Foam
-(
-    cd "${HOME}/OpenFOAM/vagrant-v2112/platforms/linux64GccDPInt32Opt/"
-    tar -xzvf swak4Foam.tar.gz
-)
+# Upgrade to OpenFOAM v2206
+# # Setup swak4Foam
+# (
+#     cd "${HOME}/OpenFOAM/vagrant-v2112/platforms/linux64GccDPInt32Opt/"
+#     tar -xzvf swak4Foam.tar.gz
+# )
 
 # Create a link to the default shared folder
 ln -sf /vagrant/ ~/Desktop/shared

--- a/provisioning/prebuilt/swak4Foam/README.txt
+++ b/provisioning/prebuilt/swak4Foam/README.txt
@@ -1,2 +1,17 @@
-Prebuilt libraries and tools of swak4Foam for Ubuntu 20.04 and OpenFOAM v2112, based on commit ea7680cdcf8b (December 2021).
+Prebuilt libraries and tools of swak4Foam for Ubuntu 20.04 and OpenFOAM v2206, based on the develop branch of swak4Foam (built on November 2022):
+
+```bash
+vagrant@precicevm:~/swak4Foam$ hg tip
+changeset:   3999:481d96f16780
+branch:      develop
+tag:         tip
+parent:      3997:4d33e38246ad
+parent:      3998:12dad7c691d1
+user:        Bernhard F.W. Gschaider <bgschaid@hfd-research.com>
+date:        Mon Jul 04 01:06:48 2022 +0200
+summary:     flow: Promoted <feature> 'port/of9' (12dad7c691d1) to 'develop'.
+```
+
+The files are extracted from `/home/vagrant/OpenFOAM/vagrant-<version>/platforms/` and copied there.
+
 Find the source code on http://hg.code.sf.net/p/openfoam-extend/swak4Foam/rev/ea7680cdcf8b

--- a/provisioning/prebuilt/swak4Foam/swak4Foam.tar.gz
+++ b/provisioning/prebuilt/swak4Foam/swak4Foam.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a6150a56f3670a237e2dbff936a5f99f900d4c71c82fa08bce9dad2795ebfae0
-size 19974607
+oid sha256:284da0859454c970ebbc208e477a8572060280eff4ba6252cd33ed24b25c4fd1
+size 20097408


### PR DESCRIPTION
Still on Ubuntu 20.04.
After the build succeeds, we still need to replace the swak4Foam compilation step with pre-built binaries, to save space and time.