### PR TITLE
Add ASTE recipe for the latest ASTE release

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ This box is based on the [generic/ubuntu2004](https://github.com/lavabit/robox/t
 - SU2 6.0.0 and the SU2-preCICE adapter (master)
 - code_aster 14.6 and the code_aster-preCICE adapter (master)
 - DUNE 2.8 and the experimental DUNE-preCICE adapter (master)
+- ASTE (vX.X)
 - Paraview from APT
 - Gnuplot
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ This box is based on the [generic/ubuntu2004](https://github.com/lavabit/robox/t
 - SU2 6.0.0 and the SU2-preCICE adapter (master)
 - code_aster 14.6 and the code_aster-preCICE adapter (master)
 - DUNE 2.8 and the experimental DUNE-preCICE adapter (master)
-- ASTE (v3.0.0)
+- ASTE (master)
 - Paraview from APT
 - Gnuplot
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ This box is based on the [generic/ubuntu2004](https://github.com/lavabit/robox/t
 - SU2 6.0.0 and the SU2-preCICE adapter (master)
 - code_aster 14.6 and the code_aster-preCICE adapter (master)
 - DUNE 2.8 and the experimental DUNE-preCICE adapter (master)
-- ASTE (vX.X)
+- ASTE (v3.0.0)
 - Paraview from APT
 - Gnuplot
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -55,6 +55,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision "shell", path: "provisioning/install-code_aster.sh", privileged: false
   config.vm.provision "shell", path: "provisioning/install-dune.sh", privileged: false
   config.vm.provision "shell", path: "provisioning/install-paraview.sh", privileged: false
+  config.vm.provision "shell", path: "provisioning/install-aste.sh", privileged: false
 
   # Post-installation steps
   config.vm.provision "shell", path: "provisioning/post-install.sh", privileged: false

--- a/provisioning/install-aste.sh
+++ b/provisioning/install-aste.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -ex
+
+# Install the C++ vtk library
+sudo apt-get -y install libvtk7-dev
+sudo apt-get -y install libmetis-dev
+
+python3 -m pip install sympy scipy jinja2
+
+# Get aste
+if [ ! -d "aste/" ]; then
+    git clone --depth=1 --branch master https://github.com/precice/aste.git
+fi
+(
+    cd aste
+    git pull
+    mkdir -p build && cd build
+    cmake .. && make -j "$(nproc)"
+)
+
+# Add aste to PATH and libmetis to the library path
+echo "export PATH=\"\${HOME}/aste:\${PATH}\"" >>~/.bashrc
+echo "export LD_LIBRARY_PATH=\"\${HOME}/aste:\${LD_LIBRARY_PATH}\"" >>~/.bashrc


### PR DESCRIPTION
... we could also test the validity of the installation by running `ctest`. Do you usually do this during the installation?