### PR TITLE
Release v202211.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ This box is based on the [generic/ubuntu2004](https://github.com/lavabit/robox/t
 - preCICE latest for the master branch
 - preCICE config visualizer (master)
 - preCICE Python bindings (PIP)
+- preCICE Julia bindings (Pkg)
 - OpenFOAM v2112 and the OpenFOAM-preCICE adapter (master)
 - deal.II 9.3 from the official backports and the deal.II-preCICE adapter (master)
 - CalculiX 2.19 from source and the CalculiX-preCICE adapter (master)

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ This box is based on the [generic/ubuntu2004](https://github.com/lavabit/robox/t
 - SU2 6.0.0 and the SU2-preCICE adapter (master)
 - code_aster 14.6 and the code_aster-preCICE adapter (master)
 - DUNE 2.8 and the experimental DUNE-preCICE adapter (master)
+- ASTE (master)
 - Paraview from APT
 - Gnuplot
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -55,6 +55,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision "shell", path: "provisioning/install-code_aster.sh", privileged: false
   config.vm.provision "shell", path: "provisioning/install-dune.sh", privileged: false
   config.vm.provision "shell", path: "provisioning/install-paraview.sh", privileged: false
+  config.vm.provision "shell", path: "provisioning/install-aste.sh", privileged: false
 
   # Post-installation steps
   config.vm.provision "shell", path: "provisioning/post-install.sh", privileged: false

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -46,7 +46,7 @@ Vagrant.configure("2") do |config|
   # Install solvers, adapters, and related tools
   config.vm.provision "shell", path: "provisioning/install-config-visualizer.sh", privileged: false
   config.vm.provision "shell", path: "provisioning/install-openfoam.sh", privileged: false
-  config.vm.provision "file", source: "provisioning/prebuilt/swak4Foam/swak4Foam.tar.gz", destination: "~/OpenFOAM/vagrant-v2112/platforms/linux64GccDPInt32Opt/swak4Foam.tar.gz"
+  config.vm.provision "file", source: "provisioning/prebuilt/swak4Foam/swak4Foam.tar.gz", destination: "~/OpenFOAM/vagrant-v2206/platforms/linux64GccDPInt32Opt/swak4Foam.tar.gz"
   config.vm.provision "shell", path: "provisioning/install-dealii.sh", privileged: false
   config.vm.provision "shell", path: "provisioning/install-calculix.sh", privileged: false
   config.vm.provision "shell", path: "provisioning/install-fenics.sh", privileged: false

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -55,6 +55,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision "shell", path: "provisioning/install-code_aster.sh", privileged: false
   config.vm.provision "shell", path: "provisioning/install-dune.sh", privileged: false
   config.vm.provision "shell", path: "provisioning/install-paraview.sh", privileged: false
+  config.vm.provision "shell", path: "provisioning/install-julia-bindings.sh", privileged: false
   config.vm.provision "shell", path: "provisioning/install-aste.sh", privileged: false
 
   # Post-installation steps

--- a/provisioning/install-aste.sh
+++ b/provisioning/install-aste.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -ex
+
+# Install the C++ vtk library
+sudo apt-get -y install libvtk7-dev
+sudo apt-get -y install libmetis-dev
+
+python3 -m pip install sympy scipy jinja2
+
+# Get aste
+if [ ! -d "aste/" ]; then
+    git clone --depth=1 --branch master https://github.com/precice/aste.git
+fi
+(
+    cd aste
+    git pull
+    mkdir -p build && cd build
+    cmake .. && make -j "$(nproc)"
+)
+
+# Add aste to PATH and libmetis to the library path
+echo "export PATH=\"\${HOME}/aste:\${PATH}\"" >>~/.bashrc
+echo "export LD_LIBRARY_PATH=\"\${HOME}/aste:\${LD_LIBRARY_PATH}\"" >>~/.bashrc

--- a/provisioning/install-aste.sh
+++ b/provisioning/install-aste.sh
@@ -19,5 +19,5 @@ fi
 )
 
 # Add aste to PATH and libmetis to the library path
-echo "export PATH=\"\${HOME}/aste:\${PATH}\"" >>~/.bashrc
-echo "export LD_LIBRARY_PATH=\"\${HOME}/aste:\${LD_LIBRARY_PATH}\"" >>~/.bashrc
+echo "export PATH=\"\${HOME}/aste/build:\${PATH}\"" >>~/.bashrc
+echo "export LD_LIBRARY_PATH=\"\${HOME}/aste/build:\${LD_LIBRARY_PATH}\"" >>~/.bashrc

--- a/provisioning/install-basics.sh
+++ b/provisioning/install-basics.sh
@@ -11,7 +11,7 @@ sudo apt-get upgrade -qy
 
 # Install the Xfce desktop environment and basic applications
 sudo apt-get install -y xubuntu-core^
-sudo apt-get install -y thunar xfce4-terminal terminator bash-completion tree evince firefox firefox-locale-en baobab catfish
+sudo apt-get install -y thunar xfce4-terminal terminator bash-completion tree atril firefox firefox-locale-en baobab catfish
 
 # Setup auto-login for the graphical session
 # Disabled due to https://github.com/precice/vm/issues/40

--- a/provisioning/install-calculix.sh
+++ b/provisioning/install-calculix.sh
@@ -5,9 +5,9 @@ set -ex
 sudo apt-get install -y libarpack2-dev libspooles-dev libyaml-cpp-dev
 
 # Install CalculiX
-wget --quiet http://www.dhondt.de/ccx_2.19.src.tar.bz2
-tar xvjf ccx_2.19.src.tar.bz2
-rm -fv ccx_2.19.src.tar.bz2
+wget --quiet http://www.dhondt.de/ccx_2.20.src.tar.bz2
+tar xvjf ccx_2.20.src.tar.bz2
+rm -fv ccx_2.20.src.tar.bz2
 
 # Get the CalculiX-preCICE adapter
 if [ ! -d "calculix-adapter/" ]; then

--- a/provisioning/install-dune.sh
+++ b/provisioning/install-dune.sh
@@ -68,5 +68,9 @@ echo "export DUNE_CONTROL_PATH=\"\${HOME}/dune\"" >> ~/.bashrc
 # Copy the built example code to the tutorials
 cp ~/dune/dune-adapter/dune-precice-howto/build-cmake/examples/dune-perpendicular-flap ~/tutorials/perpendicular-flap/solid-dune
 
+# Install dune-fem from PIP
+
+pip3 install --user dune-fem==2.8
+
 # We are done with DUNE, let's do back home
 cd ~

--- a/provisioning/install-fenics.sh
+++ b/provisioning/install-fenics.sh
@@ -9,3 +9,6 @@ sudo apt-get -y install --no-install-recommends fenics
 
 # Install the FEniCS-preCICE adapter from PIP
 pip3 install --user fenicsprecice
+
+# Remove fenics-ufl package manually
+pip3 uninstall -y fenics-ufl

--- a/provisioning/install-fenics.sh
+++ b/provisioning/install-fenics.sh
@@ -9,6 +9,3 @@ sudo apt-get -y install --no-install-recommends fenics
 
 # Install the FEniCS-preCICE adapter from PIP
 pip3 install --user fenicsprecice
-
-# Remove fenics-ufl package manually
-pip3 uninstall -y fenics-ufl

--- a/provisioning/install-julia-bindings.sh
+++ b/provisioning/install-julia-bindings.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# install latest julia
+pip3 install jill
+jill install --confirm
+
+# install preCICE bindings
+julia -e 'using Pkg; Pkg.add("PreCICE")'
+
+# to test the installation, run the following command:
+# julia -e 'using Pkg; Pkg.test("PreCICE")'

--- a/provisioning/install-nutils.sh
+++ b/provisioning/install-nutils.sh
@@ -2,4 +2,4 @@
 set -ex
 
 # Install Nutils from PIP (we will also need matplotlib in our examples)
-pip3 install --user matplotlib nutils==6.3
+pip3 install --user matplotlib nutils==7.0

--- a/provisioning/install-openfoam.sh
+++ b/provisioning/install-openfoam.sh
@@ -4,10 +4,10 @@ set -ex
 # Add the signing key, add the repository, update:
 wget -q -O - https://dl.openfoam.com/add-debian-repo.sh | sudo bash
 
-# Install OpenFOAM v2112:
-sudo apt-get install -y openfoam2112-dev
+# Install OpenFOAM v2206:
+sudo apt-get install -y openfoam2206-dev
 # Enable OpenFOAM by default:
-echo ". /usr/lib/openfoam/openfoam2112/etc/bashrc" >> ~/.bashrc
+echo ". /usr/lib/openfoam/openfoam2206/etc/bashrc" >> ~/.bashrc
 
 # Get the OpenFOAM-preCICE adapter
 if [ ! -d "openfoam-adapter/" ]; then
@@ -16,7 +16,7 @@ fi
 (
     cd openfoam-adapter
     git pull
-    openfoam2112 ./Allwmake
+    openfoam2206 ./Allwmake
 )
 
 # Get swak4Foam (provides groovyBC, needed for the turek-hron-fsi3 tutorial)
@@ -27,7 +27,7 @@ fi
 # (
 #     cd swak4Foam
 #     hg checkout develop
-#     openfoam2112 ./AllwmakeAll
+#     openfoam2206 ./AllwmakeAll
 # )
 #
 # # Remove some swak4Foam files to save space (approx. 150MB)
@@ -35,7 +35,7 @@ fi
 # sudo apt-get purge --autoremove -y mercurial # This also removes Python2, yipieh!
 #
 # # Option 2: Use pre-built binaries
-# # (see Vagrantfile and post-install.sh, rebuild and update for OpenFOAM version other than v2112)
+# # (see Vagrantfile and post-install.sh, rebuild and update for OpenFOAM version other than v2206)
 
 # Build the tutorials partitioned-heat-conduction solver
-cd ~/tutorials/partitioned-heat-conduction/openfoam-solver && openfoam2112 wmake
+cd ~/tutorials/partitioned-heat-conduction/openfoam-solver && openfoam2206 wmake

--- a/provisioning/install-precice.sh
+++ b/provisioning/install-precice.sh
@@ -41,6 +41,10 @@ if [ ! -d "tutorials/" ]; then
     ln -sf ~/tutorials ~/Desktop/
 fi
 (
+    cd tutorials/elastic-tube-1d/fluid-cpp/ && mkdir build && cd build && cmake .. && make && cd ../..
+    cd solid-cpp/ && mkdir build && cd build && cmake .. && make
+)
+(
     cd tutorials/quickstart/solid-cpp/ && cmake . && make
 )
 (

--- a/provisioning/install-precice.sh
+++ b/provisioning/install-precice.sh
@@ -55,6 +55,9 @@ sudo apt-get install -y python3-pip
 pip3 install --upgrade pip
 pip3 install --user pyprecice
 
+# Additional python packages
+pip3 install --user pandas # Needed for the post-processing script of the oscillator tutorial
+
 # Get the Python solverdummy into the examples
 if [ ! -d "python-bindings/" ]; then
     git clone --depth=1 --branch master https://github.com/precice/python-bindings.git

--- a/provisioning/install-precice.sh
+++ b/provisioning/install-precice.sh
@@ -62,6 +62,19 @@ pip3 install --user pyprecice
 # Additional python packages
 pip3 install --user pandas # Needed for the post-processing script of the oscillator tutorial
 
+# Temporary workaround for https://github.com/precice/vm/issues/61
+# Remove as soon as https://github.com/precice/tutorials/issues/217 gets resolved
+sudo apt-get install -y python3.8-venv
+(
+    cd tutorials/perpendicular-flap/fluid-nutils/
+    python3 -m venv nutils6-env
+    # shellcheck source=/dev/null
+    source nutils6-env/bin/activate
+    pip3 install nutils==6.3 pyprecice
+    sed -i "s/python3/nutils6-env\/bin\/python3/g" ./run.sh
+    deactivate
+)
+
 # Get the Python solverdummy into the examples
 if [ ! -d "python-bindings/" ]; then
     git clone --depth=1 --branch master https://github.com/precice/python-bindings.git

--- a/provisioning/install-precice.sh
+++ b/provisioning/install-precice.sh
@@ -5,10 +5,10 @@ set -ex
 sudo apt-get install -y cmake libeigen3-dev libxml2-dev libboost-all-dev petsc-dev python3-dev python3-numpy
 
 # Get preCICE from GitHub:
-# - Always get the latest master, no need for versioning
+# - Always get the latest main branch, no need for versioning
 # - Build in Debug mode, so that users can report bugs
 if [ ! -d "precice/" ]; then
-    git clone --depth=1 --branch master https://github.com/precice/precice.git
+    git clone --depth=1 --branch main https://github.com/precice/precice.git
 fi
 (
     cd precice

--- a/provisioning/post-install.sh
+++ b/provisioning/post-install.sh
@@ -7,6 +7,10 @@ set -ex
     tar -xzvf swak4Foam.tar.gz
 )
 
+# Remove fenics-ufl package
+# Workaround for https://github.com/precice/vm/issues/4
+pip3 uninstall -y fenics-ufl
+
 # Create a link to the default shared folder
 ln -sf /vagrant/ ~/Desktop/shared
 

--- a/provisioning/post-install.sh
+++ b/provisioning/post-install.sh
@@ -3,7 +3,7 @@ set -ex
 
 # Setup swak4Foam
 (
-    cd "${HOME}/OpenFOAM/vagrant-v2112/platforms/linux64GccDPInt32Opt/"
+    cd "${HOME}/OpenFOAM/vagrant-v2206/platforms/linux64GccDPInt32Opt/"
     tar -xzvf swak4Foam.tar.gz
 )
 

--- a/provisioning/prebuilt/swak4Foam/README.txt
+++ b/provisioning/prebuilt/swak4Foam/README.txt
@@ -1,2 +1,17 @@
-Prebuilt libraries and tools of swak4Foam for Ubuntu 20.04 and OpenFOAM v2112, based on commit ea7680cdcf8b (December 2021).
+Prebuilt libraries and tools of swak4Foam for Ubuntu 20.04 and OpenFOAM v2206, based on the develop branch of swak4Foam (built on November 2022):
+
+```bash
+vagrant@precicevm:~/swak4Foam$ hg tip
+changeset:   3999:481d96f16780
+branch:      develop
+tag:         tip
+parent:      3997:4d33e38246ad
+parent:      3998:12dad7c691d1
+user:        Bernhard F.W. Gschaider <bgschaid@hfd-research.com>
+date:        Mon Jul 04 01:06:48 2022 +0200
+summary:     flow: Promoted <feature> 'port/of9' (12dad7c691d1) to 'develop'.
+```
+
+The files are extracted from `/home/vagrant/OpenFOAM/vagrant-<version>/platforms/` and copied there.
+
 Find the source code on http://hg.code.sf.net/p/openfoam-extend/swak4Foam/rev/ea7680cdcf8b

--- a/provisioning/prebuilt/swak4Foam/swak4Foam.tar.gz
+++ b/provisioning/prebuilt/swak4Foam/swak4Foam.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a6150a56f3670a237e2dbff936a5f99f900d4c71c82fa08bce9dad2795ebfae0
-size 19974607
+oid sha256:284da0859454c970ebbc208e477a8572060280eff4ba6252cd33ed24b25c4fd1
+size 20097408


### PR DESCRIPTION
Continuing with unreleased changes from https://github.com/precice/vm/pull/44.

## New changes

- Added ASTE and Julia bindings
- Added dune-fem
- Added the binaries of the elastic-tube-1d C++ solvers
- Upgraded OpenFOAM to v2206, CalculiX to v2.20, and Nutils to v7.2 (with a special case for the `perpendicular-flap/fluid-nutils` tutorial case)
- Added the Python pandas package
- Replaced the PDF reader Evince with Atril, fixing an issue with opening URLs
- Updated preCICE branch name (`master`->`main`)

## Previously unreleased changes

- Added libvirt support (experimental)
- Updated a few CI-related things