### PR TITLE
Update version of Nutils installed

### DIFF
--- a/provisioning/install-nutils.sh
+++ b/provisioning/install-nutils.sh
@@ -2,4 +2,4 @@
 set -ex
 
 # Install Nutils from PIP (we will also need matplotlib in our examples)
-pip3 install --user matplotlib nutils==6.3
+pip3 install --user matplotlib nutils==7.0


### PR DESCRIPTION
The channel-transport tutorial case does not work with the existing Nutils in the vm (v6.3) as mentioned in https://github.com/precice/tutorials/pull/305#issuecomment-1321951770. This PR changes the Nutils version to be installed to v7.0, with which all the tutorials work (or are expected to work).