### PR TITLE
Add venv with Nutils 6 for perpendicular-flap

### DIFF
--- a/provisioning/install-precice.sh
+++ b/provisioning/install-precice.sh
@@ -62,6 +62,18 @@ pip3 install --user pyprecice
 # Additional python packages
 pip3 install --user pandas # Needed for the post-processing script of the oscillator tutorial
 
+# Temporary workaround for https://github.com/precice/vm/issues/61
+# Remove as soon as https://github.com/precice/tutorials/issues/217 gets resolved
+sudo apt-get install -y python3.8-venv
+(
+    cd tutorials/perpendicular-flap/fluid-nutils/
+    python3 -m venv nutils6-env
+    source nutils6-env/bin/activate
+    pip3 install nutils==6.3 pyprecice
+    sed -i "s/python3/nutils6-env\/bin\/python3/g" ./run.sh
+    deactivate
+)
+
 # Get the Python solverdummy into the examples
 if [ ! -d "python-bindings/" ]; then
     git clone --depth=1 --branch master https://github.com/precice/python-bindings.git


### PR DESCRIPTION
Closes #61

This creates a virtual environment in the respective tutorials directory, installs nutils 6.3 (and `pyprecice` again, since we normally install it for the user) and replaces the `python3` binary name in the respective `run.sh` script with `nutils6-env/bin/python3`.

This is only a temporary workaround, to be removed as soon as https://github.com/precice/tutorials/issues/217 gets resolved.
