### PR TITLE
Add cargo (Rust)

### DIFF
--- a/provisioning/install-devel.sh
+++ b/provisioning/install-devel.sh
@@ -3,6 +3,9 @@ set -ex
 
 sudo apt-get install -y build-essential git cmake cmake-curses-gui
 
+# For the Rust bindings of preCICE, installed by the elastic-tube-1d tutorial
+sudo apt-get install -y cargo
+
 sudo apt-get install -y nano vim gedit
 
 sudo apt-get install -y meld

--- a/provisioning/install-precice.sh
+++ b/provisioning/install-precice.sh
@@ -44,6 +44,12 @@ fi
     cd tutorials/quickstart/solid-cpp/ && cmake . && make
 )
 (
+    cd tutorials/elastic-tube-1d/solid-rust/ && mkdir -p .cargo && cargo vendor > .cargo/config.toml
+)
+(
+    cd tutorials/elastic-tube-1d/fluid-rust/ && mkdir -p .cargo && cargo vendor > .cargo/config.toml
+)
+(
     cd tutorials/heat-exchanger && ./download-meshes.sh
 )
 sudo apt-get -y install gnuplot # needed for watchpoint scripts of tutorials


### PR DESCRIPTION
Closes #79

The elastic-tube-1d tutorial should install the Rust bindings and related dependencies on first run.