### PR TITLE
Revert back to bento/ubuntu-20.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ A few things you may need:
 
 ## What is included?
 
-This box is based on the [generic/ubuntu2004](https://github.com/lavabit/robox/tree/master/scripts/ubuntu2004) base box and installs:
+This box is based on the ~~[generic/ubuntu2004](https://github.com/lavabit/robox/tree/master/scripts/ubuntu2004)~~ [bento/ubuntu-20.04](https://github.com/chef/bento) base box and installs:
 
 - Xubuntu-core (Xfce desktop environment) and related tools
 - VirtualBox guest additions
@@ -119,6 +119,11 @@ vagrant box remove test-box
 
 If you require a more responsive experience, lower overhead, or exotic features such as GPU pass through, then the `libvirt` vagrant box is for you.
 This allows you to run the vagrant box via libvirt and QEMU as a Kernerl Virtual Machine (KVM).
+
+> Note
+> The libvirt variant does not work with the `bento/ubuntu-20.04` base image, but also the VirtualBox variant does not at the moment work with the `generic/ubuntu2004` image.
+> Change the base image in the beginning of the Vagrantfile if you need this feature.
+> See https://github.com/precice/vm/issues/83 for details.
 
 To use this box, first install the vagrant plugin `vagrant-libvirt` following the [official installation instructions](https://github.com/vagrant-libvirt/vagrant-libvirt#installation).
 Then you follow the normal usage instructions above, but you need to tell vagrant to use the `libvirt` box by passing one additional option:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,9 @@
 Vagrant.configure("2") do |config|
   # The generic/ images support virtualbox as well as libvirt and hyperv.
   # This allows us to create performance oriented images for Linux (libvirt) and Windows (hyperv).
-  config.vm.box = "generic/ubuntu2004"
+  # However, it does not build: https://github.com/precice/vm/issues/83
+  # config.vm.box = "generic/ubuntu2004"
+  config.vm.box = "bento/ubuntu-20.04"
 
   # We don't want the box to automatically update every time it starts.
   # We can instead handle updates internally, without destroying the machine.


### PR DESCRIPTION
Closes #83.

Conflicts with #25. @fsimonis we primarily need VirtualBox, so I would not like that the libvirt support blocks the rest. If we later find a fix, that's fine.

I have added some notes in the README.