### PR TITLE
Downgrade base box version

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,6 +7,7 @@ Vagrant.configure("2") do |config|
   # However, it does not build: https://github.com/precice/vm/issues/83
   # config.vm.box = "generic/ubuntu2004"
   config.vm.box = "bento/ubuntu-20.04"
+  config.vm.box_version = "202401.31.0"
 
   # We don't want the box to automatically update every time it starts.
   # We can instead handle updates internally, without destroying the machine.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,9 +5,9 @@ Vagrant.configure("2") do |config|
   # The generic/ images support virtualbox as well as libvirt and hyperv.
   # This allows us to create performance oriented images for Linux (libvirt) and Windows (hyperv).
   # However, it does not build: https://github.com/precice/vm/issues/83
-  config.vm.box = "generic/ubuntu2004"
-  # config.vm.box = "bento/ubuntu-20.04"
-  # config.vm.box_version = "202401.31.0"
+  # config.vm.box = "generic/ubuntu2004"
+  config.vm.box = "bento/ubuntu-20.04"
+  config.vm.box_version = "v202309.09.0"
 
   # We don't want the box to automatically update every time it starts.
   # We can instead handle updates internally, without destroying the machine.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,7 +7,7 @@ Vagrant.configure("2") do |config|
   # However, it does not build: https://github.com/precice/vm/issues/83
   # config.vm.box = "generic/ubuntu2004"
   config.vm.box = "bento/ubuntu-20.04"
-  config.vm.box_version = "v202309.09.0"
+  config.vm.box_version = "202309.09.0"
 
   # We don't want the box to automatically update every time it starts.
   # We can instead handle updates internally, without destroying the machine.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,9 +5,9 @@ Vagrant.configure("2") do |config|
   # The generic/ images support virtualbox as well as libvirt and hyperv.
   # This allows us to create performance oriented images for Linux (libvirt) and Windows (hyperv).
   # However, it does not build: https://github.com/precice/vm/issues/83
-  # config.vm.box = "generic/ubuntu2004"
-  config.vm.box = "bento/ubuntu-20.04"
-  config.vm.box_version = "202401.31.0"
+  config.vm.box = "generic/ubuntu2004"
+  # config.vm.box = "bento/ubuntu-20.04"
+  # config.vm.box_version = "202401.31.0"
 
   # We don't want the box to automatically update every time it starts.
   # We can instead handle updates internally, without destroying the machine.


### PR DESCRIPTION
Trying to understand why the VM does not build anymore in the GitHub-hosted runners.
On my laptop, it works, and I currently have the version `202401.31.0` of `bento/ubuntu-20.04`.
A newer version was released earlier today, and that could explain why I observed that it was building earlier today but not again after some point, even though the times do not exactly match.

Edit:

- Switching to `bento/ubuntu-20.04` 202401.31.0 did not help. `202309.09.0` also did not help.
- With `'generic/ubuntu2004' (v4.3.12)`, it goes beyond that point, but then fails because of #83.