### PR TITLE
Convert provisioning shell scripts to reusable Ansible playbooks (#96)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: Ansible CI with Docker
+
+on: [push, pull_request]
+
+jobs:
+  test-ansible:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Build environment
+        run: sudo apt-get update && sudo apt-get install -y docker.io
+
+      - name: Build test container
+        run: |
+          docker build -t ansible-test -f - . <<EOF
+          FROM ubuntu:24.04
+
+          ENV DEBIAN_FRONTEND=noninteractive
+
+          RUN apt-get update && \
+              apt-get install -y \
+                python3 python3-pip python3-venv sudo git curl wget software-properties-common && \
+              pip3 install ansible ansible-lint && \
+              apt-get clean
+
+          WORKDIR /workspace
+          EOF
+
+      - name: Copy repo into container and run Ansible
+        run: |
+          docker run --rm -v ${{ github.workspace }}:/workspace -w /workspace ansible-test bash -c "
+            ansible-lint ansible/playbooks/
+            for playbook in ansible/playbooks/*.yml; do
+              echo 'Checking syntax of' \$playbook
+              ansible-playbook -i ansible/inventory.ini --syntax-check \$playbook
+            done
+          "

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,29 +10,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up Docker Build environment
-        run: sudo apt-get update && sudo apt-get install -y docker.io
+      - name: Lint Ansible Playbooks 🧹
+        uses: docker://ansible/ansible-lint:latest
+        with:
+          args: 'ansible/playbooks/'
 
-      - name: Build test container
+      - name: Check Ansible Playbook Syntax ✅
         run: |
-          docker build -t ansible-test -f - . <<EOF
-          FROM ubuntu:24.04
-
-          ENV DEBIAN_FRONTEND=noninteractive
-
-          RUN apt-get update && \
-              apt-get install -y \
-                python3 python3-pip python3-venv sudo git curl wget software-properties-common && \
-              pip3 install ansible ansible-lint && \
-              apt-get clean
-
-          WORKDIR /workspace
-          EOF
-
-      - name: Copy repo into container and run Ansible
-        run: |
-          docker run --rm -v ${{ github.workspace }}:/workspace -w /workspace ansible-test bash -c "
-            ansible-lint ansible/playbooks/
+          docker run --rm -v ${{ github.workspace }}:/workspace -w /workspace ansible/ansible:latest bash -c "
             for playbook in ansible/playbooks/*.yml; do
               echo 'Checking syntax of' \$playbook
               ansible-playbook -i ansible/inventory.ini --syntax-check \$playbook

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -1,7 +1,7 @@
 Ansible Playbooks for preCICE Development Environment Setup
 This repository contains a set of Ansible playbooks that automate the provisioning of the preCICE development environment. These playbooks are converted from original `.sh` shell scripts, making the setup process modular, idempotent, and more maintainable.
 ## 📁 Directory Structure
-
+´´´
 ansible/
 ├── inventory.ini          # Target hosts configuration
 ├── playbooks/             # Individual provisioning playbooks
@@ -23,7 +23,7 @@ ansible/
 │   ├── install-su2.yml
 │   └── install-vscode.yml
 └── README.md              # This file
-
+´´´
 ## ✅ Purpose
 These playbooks set up all necessary software components and development tools for contributing to or working with preCICE, a coupling library for partitioned multi-physics simulations.
 The playbooks were translated from original shell scripts to:

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -1,0 +1,68 @@
+Ansible Playbooks for preCICE Development Environment Setup
+This repository contains a set of Ansible playbooks that automate the provisioning of the preCICE development environment. These playbooks are converted from original `.sh` shell scripts, making the setup process modular, idempotent, and more maintainable.
+## 📁 Directory Structure
+
+ansible/
+├── inventory.ini          # Target hosts configuration
+├── playbooks/             # Individual provisioning playbooks
+│   ├── install-basics.yml
+│   ├── install-aste.yml
+│   ├── install-calculix.yml
+│   ├── install-code_aster.yml
+│   ├── install-config-visualizer.yml
+│   ├── install-dealii.yml
+│   ├── install-devel.yml
+│   ├── install-dune.yml
+│   ├── install-fenics.yml
+│   ├── install-fmiprecice.yml
+│   ├── install-julia-bindings.yml
+│   ├── install-micro-manager.yml
+│   ├── install-openfoam.yml
+│   ├── install-paraview.yml
+│   ├── install-precice.yml
+│   ├── install-su2.yml
+│   └── install-vscode.yml
+└── README.md              # This file
+
+## ✅ Purpose
+These playbooks set up all necessary software components and development tools for contributing to or working with preCICE, a coupling library for partitioned multi-physics simulations.
+The playbooks were translated from original shell scripts to:
+- Ensure idempotency (safe to re-run)
+- Improve clarity and maintainability
+- Allow easier customization and reuse
+- Support inventory-based execution (local or remote hosts)
+## 🛠️ Conversion: Shell Script → Ansible Playbook
+
+| Shell Script Action             | Ansible Equivalent             |
+|--------------------------------|--------------------------------|
+| apt-get update/install         | apt module with update_cache   |
+| adduser, usermod               | user and group modules         |
+| chmod +x / mkdir -p            | file module with mode/path     |
+| curl or wget scripts           | get_url or uri module          |
+| bash install.sh                | script or command module       |
+| systemctl enable/start         | systemd module                 |
+
+## 🚀 Usage
+### 1. Clone the repository
+git clone https://github.com/<your-username>/ansible.git
+cd ansible
+### 2. Update inventory
+[local]
+localhost ansible_connection=local
+### 3. Run a playbook
+ansible-playbook -i inventory.ini playbooks/install-precice.yml
+## 🔍 Testing & Validation
+- All playbooks tested on Ubuntu 22.04 using Vagrant VM
+- Playbooks support `--check` mode for dry-run testing
+ansible-playbook -i inventory.ini playbooks/install-precice.yml --check --diff
+- Playbooks can be extended with tags and variables
+## 📌 Notes
+- These playbooks do not use Ansible roles yet, but future restructuring may modularize common logic (e.g., user setup, package installation)
+- Ensure Python and `sudo` are available on the target machines
+## 📈 Next Steps
+- Add Molecule-based testing
+- Introduce group_vars for better parameterization
+- Modularize with Ansible roles (e.g., docker, precice, visualization)
+## 🤝 Contributing
+Pull requests and suggestions are welcome! If you have a shell script you’d like converted into an Ansible playbook, open an issue or contribute directly.
+

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -1,7 +1,7 @@
 Ansible Playbooks for preCICE Development Environment Setup
 This repository contains a set of Ansible playbooks that automate the provisioning of the preCICE development environment. These playbooks are converted from original `.sh` shell scripts, making the setup process modular, idempotent, and more maintainable.
 ## 📁 Directory Structure
-´´´
+```
 ansible/
 ├── inventory.ini          # Target hosts configuration
 ├── playbooks/             # Individual provisioning playbooks
@@ -23,7 +23,7 @@ ansible/
 │   ├── install-su2.yml
 │   └── install-vscode.yml
 └── README.md              # This file
-´´´
+```
 ## ✅ Purpose
 These playbooks set up all necessary software components and development tools for contributing to or working with preCICE, a coupling library for partitioned multi-physics simulations.
 The playbooks were translated from original shell scripts to:

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -1,68 +1,11 @@
-Ansible Playbooks for preCICE Development Environment Setup
-This repository contains a set of Ansible playbooks that automate the provisioning of the preCICE development environment. These playbooks are converted from original `.sh` shell scripts, making the setup process modular, idempotent, and more maintainable.
-## 📁 Directory Structure
+# Ansible playbooks for preCICE
+
+This repository contains a set of Ansible playbooks that automate the provisioning of a system with preCICE and several adapters and further tools installed. These playbooks are converted from the original shell scripts, making the setup process modular, idempotent, and more maintainable.
+
+To run a specific playbook, get Ansible (e.g., `sudo apt install ansible`) and execute from this directory, for example:
+
+```shell
+ansible-playbook -i inventory.ini playbooks/install-basics.yml
 ```
-ansible/
-├── inventory.ini          # Target hosts configuration
-├── playbooks/             # Individual provisioning playbooks
-│   ├── install-basics.yml
-│   ├── install-aste.yml
-│   ├── install-calculix.yml
-│   ├── install-code_aster.yml
-│   ├── install-config-visualizer.yml
-│   ├── install-dealii.yml
-│   ├── install-devel.yml
-│   ├── install-dune.yml
-│   ├── install-fenics.yml
-│   ├── install-fmiprecice.yml
-│   ├── install-julia-bindings.yml
-│   ├── install-micro-manager.yml
-│   ├── install-openfoam.yml
-│   ├── install-paraview.yml
-│   ├── install-precice.yml
-│   ├── install-su2.yml
-│   └── install-vscode.yml
-└── README.md              # This file
-```
-## ✅ Purpose
-These playbooks set up all necessary software components and development tools for contributing to or working with preCICE, a coupling library for partitioned multi-physics simulations.
-The playbooks were translated from original shell scripts to:
-- Ensure idempotency (safe to re-run)
-- Improve clarity and maintainability
-- Allow easier customization and reuse
-- Support inventory-based execution (local or remote hosts)
-## 🛠️ Conversion: Shell Script → Ansible Playbook
 
-| Shell Script Action             | Ansible Equivalent             |
-|--------------------------------|--------------------------------|
-| apt-get update/install         | apt module with update_cache   |
-| adduser, usermod               | user and group modules         |
-| chmod +x / mkdir -p            | file module with mode/path     |
-| curl or wget scripts           | get_url or uri module          |
-| bash install.sh                | script or command module       |
-| systemctl enable/start         | systemd module                 |
-
-## 🚀 Usage
-### 1. Clone the repository
-git clone https://github.com/<your-username>/ansible.git
-cd ansible
-### 2. Update inventory
-[local]
-localhost ansible_connection=local
-### 3. Run a playbook
-ansible-playbook -i inventory.ini playbooks/install-precice.yml
-## 🔍 Testing & Validation
-- All playbooks tested on Ubuntu 22.04 using Vagrant VM
-- Playbooks support `--check` mode for dry-run testing
-ansible-playbook -i inventory.ini playbooks/install-precice.yml --check --diff
-- Playbooks can be extended with tags and variables
-## 📌 Notes
-- These playbooks do not use Ansible roles yet, but future restructuring may modularize common logic (e.g., user setup, package installation)
-- Ensure Python and `sudo` are available on the target machines
-## 📈 Next Steps
-- Add Molecule-based testing
-- Introduce group_vars for better parameterization
-- Modularize with Ansible roles (e.g., docker, precice, visualization)
-## 🤝 Contributing
-Pull requests and suggestions are welcome! If you have a shell script you’d like converted into an Ansible playbook, open an issue or contribute directly.
-
+To check (dry-run) the playbooks, use the `--check --diff` flags.

--- a/ansible/inventory.ini
+++ b/ansible/inventory.ini
@@ -1,0 +1,5 @@
+[local]
+localhost ansible_connection=local
+
+[remote]
+# Example: server1 ansible_host=192.168.1.100 ansible_user=youruser

--- a/ansible/playbooks/install-aste.yml
+++ b/ansible/playbooks/install-aste.yml
@@ -1,0 +1,70 @@
+---
+- name: Install aste with dependencies
+  hosts: localhost
+  connection: local
+  become: true
+  vars:
+    user_home: "{{ lookup('env', 'HOME') }}"
+    aste_repo_url: "https://github.com/precice/aste.git"
+    aste_path: "{{ user_home }}/aste"
+    aste_venv_path: "{{ user_home }}/python-venvs/aste"
+
+  tasks:
+    - name: Install system dependencies for aste
+      apt:
+        name:
+          - libvtk9-dev
+          - libvtk9-qt-dev
+          - libmetis-dev
+          - python3-venv
+          - python3-pip
+        state: present
+        update_cache: yes
+
+    - name: Create Python virtual environment for aste
+      become: false
+      command: python3 -m venv {{ aste_venv_path }}
+      args:
+        creates: "{{ aste_venv_path }}/bin/activate"
+
+    - name: Install Python packages in aste venv
+      become: false
+      shell: |
+        source {{ aste_venv_path }}/bin/activate
+        pip install --upgrade pip
+        pip install sympy scipy jinja2
+      args:
+        executable: /bin/bash
+
+    - name: Clone aste repository
+      become: false
+      git:
+        repo: "{{ aste_repo_url }}"
+        dest: "{{ aste_path }}"
+        version: master
+        depth: 1
+        update: yes
+
+    - name: Build aste project
+      become: false
+      shell: |
+        mkdir -p build && cd build
+        cmake ..
+        make -j $(nproc)
+      args:
+        chdir: "{{ aste_path }}"
+        executable: /bin/bash
+
+    - name: Add aste build path to PATH in .bashrc
+      become: false
+      lineinfile:
+        path: "{{ user_home }}/.bashrc"
+        line: 'export PATH="${HOME}/aste/build:${PATH}"'
+        insertafter: EOF
+
+    - name: Add aste build path to LD_LIBRARY_PATH in .bashrc
+      become: false
+      lineinfile:
+        path: "{{ user_home }}/.bashrc"
+        line: 'export LD_LIBRARY_PATH="${HOME}/aste/build:${LD_LIBRARY_PATH}"'
+        insertafter: EOF

--- a/ansible/playbooks/install-basics.yml
+++ b/ansible/playbooks/install-basics.yml
@@ -1,0 +1,17 @@
+# install-basics.yml
+- name: Install basic packages
+  hosts: all
+  become: true
+  tasks:
+    - name: Update apt
+      apt:
+        update_cache: yes
+
+    - name: Install essential packages
+      apt:
+        name: "{{ item }}"
+        state: present
+      loop:
+        - build-essential
+        - cmake
+        - git

--- a/ansible/playbooks/install-basics.yml
+++ b/ansible/playbooks/install-basics.yml
@@ -1,17 +1,97 @@
-# install-basics.yml
-- name: Install basic packages
+---
+- name: Install GUI, development tools, and setup VM environment
   hosts: all
   become: true
+
+  vars:
+    keyboard_layout: us
+    hostname: precicevm
+    desktop_shortcut: /usr/share/applications/xfce-keyboard-settings.desktop
+
+  pre_tasks:
+    - name: Remove bad APT retry config if present
+      file:
+        path: /etc/apt/apt.conf.d/80-retries
+        state: absent
+
+    - name: Set correct APT retry config
+      copy:
+        dest: /etc/apt/apt.conf.d/80-retries
+        content: |
+          Acquire::Retries "4";
+        force: yes
+
   tasks:
-    - name: Update apt
+    - name: Add multiverse repository
+      apt_repository:
+        repo: "deb http://archive.ubuntu.com/ubuntu {{ ansible_distribution_release }} multiverse"
+        state: present
+        filename: multiverse
+
+    - name: Update APT cache
       apt:
         update_cache: yes
 
-    - name: Install essential packages
+    - name: Upgrade packages
       apt:
-        name: "{{ item }}"
+        upgrade: dist
+        force_apt_get: yes
+
+    - name: Install Xfce desktop environment
+      apt:
+        name: xubuntu-core
         state: present
-      loop:
-        - build-essential
-        - cmake
-        - git
+
+    - name: Install GUI and terminal apps
+      apt:
+        name:
+          - thunar
+          - xfce4-terminal
+          - terminator
+          - bash-completion
+          - tree
+          - atril
+          - firefox
+          - firefox-locale-en
+          - baobab
+          - catfish
+        state: present
+
+    - name: Install Python development tools
+      apt:
+        name:
+          - python3-dev
+          - pipx
+          - python-is-python3
+          - python3-venv
+        state: present
+
+    - name: Install VirtualBox Guest Additions
+      apt:
+        name:
+          - virtualbox-guest-utils
+          - virtualbox-guest-x11
+        state: present
+
+    - name: Create Desktop directory if not present
+      file:
+        path: "{{ ansible_env.HOME }}/Desktop"
+        state: directory
+        mode: '0755'
+
+    - name: Set US keyboard layout
+      lineinfile:
+        path: /etc/default/keyboard
+        regexp: '^XKBLAYOUT='
+        line: 'XKBLAYOUT="{{ keyboard_layout }}"'
+
+    - name: Copy keyboard settings shortcut to Desktop
+      copy:
+        src: "{{ desktop_shortcut }}"
+        dest: "{{ ansible_env.HOME }}/Desktop/"
+        remote_src: yes
+        mode: '0755'
+
+    - name: Set hostname
+      hostname:
+        name: "{{ hostname }}"

--- a/ansible/playbooks/install-basics.yml
+++ b/ansible/playbooks/install-basics.yml
@@ -1,19 +1,14 @@
 ---
-- name: Install GUI, development tools, and setup VM environment
+- name: Install a dekstop environment, basic tools, and VM guest additions
   hosts: all
   become: true
 
   vars:
     keyboard_layout: us
     hostname: precicevm
-    desktop_shortcut: /usr/share/applications/xfce-keyboard-settings.desktop
 
   pre_tasks:
-    - name: Remove bad APT retry config if present
-      file:
-        path: /etc/apt/apt.conf.d/80-retries
-        state: absent
-
+    # Some repos are a bit fragile and need multiple download tries.
     - name: Set correct APT retry config
       copy:
         dest: /etc/apt/apt.conf.d/80-retries
@@ -22,6 +17,7 @@
         force: yes
 
   tasks:
+    # We (may) need the multiverse repository for the VBox Guest Additions
     - name: Add multiverse repository
       apt_repository:
         repo: "deb http://archive.ubuntu.com/ubuntu {{ ansible_distribution_release }} multiverse"
@@ -34,7 +30,7 @@
 
     - name: Upgrade packages
       apt:
-        upgrade: dist
+        upgrade: yes
         force_apt_get: yes
 
     - name: Install Xfce desktop environment
@@ -57,7 +53,7 @@
           - catfish
         state: present
 
-    - name: Install Python development tools
+    - name: Install Python
       apt:
         name:
           - python3-dev
@@ -79,7 +75,7 @@
         state: directory
         mode: '0755'
 
-    - name: Set US keyboard layout
+    - name: Set keyboard layout
       lineinfile:
         path: /etc/default/keyboard
         regexp: '^XKBLAYOUT='
@@ -87,7 +83,7 @@
 
     - name: Copy keyboard settings shortcut to Desktop
       copy:
-        src: "{{ desktop_shortcut }}"
+        src: /usr/share/applications/xfce-keyboard-settings.desktop
         dest: "{{ ansible_env.HOME }}/Desktop/"
         remote_src: yes
         mode: '0755'

--- a/ansible/playbooks/install-calculix.yml
+++ b/ansible/playbooks/install-calculix.yml
@@ -1,0 +1,65 @@
+---
+- name: Install CalculiX and the preCICE adapter
+  hosts: all
+  become: true
+  vars:
+    user_home: "{{ lookup('env', 'HOME') }}"
+    calculix_url: "http://www.dhondt.de/ccx_2.20.src.tar.bz2"
+    calculix_tarball: "ccx_2.20.src.tar.bz2"
+    calculix_dir: "ccx_2.20"
+    adapter_repo_url: "https://github.com/precice/calculix-adapter.git"
+    adapter_path: "{{ user_home }}/calculix-adapter"
+
+  tasks:
+    - name: Install dependencies for CalculiX
+      apt:
+        name:
+          - libarpack2-dev
+          - libspooles-dev
+          - libyaml-cpp-dev
+        state: present
+        update_cache: yes
+
+    - name: Download CalculiX source tarball
+      become: false
+      get_url:
+        url: "{{ calculix_url }}"
+        dest: "{{ user_home }}/{{ calculix_tarball }}"
+        mode: '0644'
+
+    - name: Extract CalculiX source
+      become: false
+      unarchive:
+        src: "{{ user_home }}/{{ calculix_tarball }}"
+        dest: "{{ user_home }}"
+        remote_src: true
+
+    - name: Remove CalculiX tarball
+      become: false
+      file:
+        path: "{{ user_home }}/{{ calculix_tarball }}"
+        state: absent
+
+    - name: Clone CalculiX adapter repository
+      become: false
+      git:
+        repo: "{{ adapter_repo_url }}"
+        dest: "{{ adapter_path }}"
+        version: master
+        depth: 1
+        update: yes
+
+    - name: Build CalculiX adapter
+      become: false
+      shell: |
+        make -j $(nproc) ADDITIONAL_FFLAGS=-fallow-argument-mismatch
+      args:
+        chdir: "{{ adapter_path }}"
+        executable: /bin/bash
+
+    - name: Add CalculiX adapter to PATH in .bashrc
+      become: false
+      lineinfile:
+        path: "{{ user_home }}/.bashrc"
+        line: 'export PATH="{{ user_home }}/calculix-adapter/bin:$PATH"'
+        insertafter: EOF

--- a/ansible/playbooks/install-code_aster.yml
+++ b/ansible/playbooks/install-code_aster.yml
@@ -1,0 +1,151 @@
+---
+- name: Install Code_Aster and its preCICE adapter
+  hosts: all
+  become: true
+  vars:
+    aster_url: "https://www.code-aster.org/FICHIERS/aster-full-src-14.6.0-1.noarch.tar.gz"
+    aster_tarball: "aster-full-src-14.6.0-1.noarch.tar.gz"
+    aster_extract_dir: "aster-full-src-14.6.0"
+    aster_install_path: "{{ ansible_env.HOME }}/code_aster"
+    adapter_repo_url: "https://github.com/precice/code_aster-adapter.git"
+    adapter_path: "{{ ansible_env.HOME }}/code_aster-adapter"
+    tutorial_path: "{{ ansible_env.HOME }}/tutorials/flow-over-heated-plate-steady-state"
+
+  tasks:
+    - name: Install Code_Aster dependencies
+      apt:
+        name:
+          - bison
+          - cmake
+          - make
+          - flex
+          - g++
+          - gcc
+          - gfortran
+          - grace
+          - liblapack-dev
+          - libblas-dev
+          - libboost-numpy-dev
+          - libboost-python-dev
+          - python3
+          - python3-dev
+          - python3-numpy
+          - tk
+          - zlib1g-dev
+        state: present
+        update_cache: yes
+
+    - name: Download Code_Aster tarball
+      become: false
+      get_url:
+        url: "{{ aster_url }}"
+        dest: "{{ ansible_env.HOME }}/{{ aster_tarball }}"
+        mode: '0644'
+
+    - name: Extract Code_Aster source
+      become: false
+      unarchive:
+        src: "{{ ansible_env.HOME }}/{{ aster_tarball }}"
+        dest: "{{ ansible_env.HOME }}"
+        remote_src: yes
+
+    - name: Install Code_Aster to user directory
+      become: false
+      shell: |
+        yes | python3 setup.py install --prefix="{{ aster_install_path }}"
+      args:
+        chdir: "{{ ansible_env.HOME }}/{{ aster_extract_dir }}"
+        executable: /bin/bash
+
+    - name: Clean up extracted Code_Aster source
+      become: false
+      file:
+        path: "{{ ansible_env.HOME }}/{{ aster_extract_dir }}"
+        state: absent
+
+    - name: Add Code_Aster to .bashrc
+      become: false
+      lineinfile:
+        path: "{{ ansible_env.HOME }}/.bashrc"
+        line: '. {{ aster_install_path }}/etc/codeaster/profile.sh'
+        insertafter: EOF
+
+    - name: Clone Code_Aster adapter
+      become: false
+      git:
+        repo: "{{ adapter_repo_url }}"
+        dest: "{{ adapter_path }}"
+        version: master
+        depth: 1
+        update: yes
+
+    - name: Symlink adapter.py to Code_Aster Execution directory
+      become: false
+      file:
+        src: "{{ adapter_path }}/cht/adapter.py"
+        dest: "{{ aster_install_path }}/14.6/lib/aster/Execution/adapter.py"
+        state: link
+
+    - name: Remove tests from Code_Aster to save space
+      become: false
+      file:
+        path: "{{ aster_install_path }}/14.6/share/aster/tests"
+        state: absent
+
+    - name: Remove documentation from Code_Aster to save space
+      become: false
+      file:
+        path: "{{ aster_install_path }}/public/med-4.00/share/doc"
+        state: absent
+
+    - name: Update exchange directory path in precice-config.xml
+      become: false
+      replace:
+        path: "{{ tutorial_path }}/precice-config.xml"
+        regexp: 'exchange-directory=".."'
+        replace: 'exchange-directory="{{ tutorial_path }}"'
+
+    - name: Generate solid.export file for solid-codeaster
+      become: false
+      shell: |
+        if [ ! -f solid.export ]; then
+          cat <<EOF > solid.export
+P actions make_etude
+P aster_root /code_aster
+P consbtc oui
+P debug nodebug
+P display precicevm:0
+P follow_output yes
+P mclient precicevm
+P memjob 524288
+P memory_limit 512.0
+P mode interactif
+P ncpus 1
+P nomjob linear-thermic
+P origine salomemeca_asrun 1.10.0
+P protocol_copyfrom asrun.plugins.server.SCPServer
+P protocol_copyto asrun.plugins.server.SCPServer
+P protocol_exec asrun.plugins.server.SSHServer
+P rep_trav /tmp/root-23129e00f0db-interactif_4800
+P serveur localhost
+P soumbtc oui
+P time_limit 600.0
+P tpsjob 11
+P uclient precicevm
+P username precicevm
+P version stable
+A memjeveux 64.0
+A tpmax 600.0
+F comm ${HOME}/code_aster-adapter/cht/adapter.comm D 1
+F libr $(pwd)/config.comm D 90
+F libr $(pwd)/def.comm D 91
+F mmed $(pwd)/solid.mmed D 20
+R repe $(pwd)/REPE_OUT D 0
+R repe $(pwd)/REPE_OUT R 0
+F mess $(pwd)/solid.mess R 6
+F resu $(pwd)/solid.resu R 8
+EOF
+        fi
+      args:
+        chdir: "{{ tutorial_path }}/solid-codeaster"
+        executable: /bin/bash

--- a/ansible/playbooks/install-config-visualizer.yml
+++ b/ansible/playbooks/install-config-visualizer.yml
@@ -1,0 +1,91 @@
+---
+- name: Install preCICE Config Visualizer CLI and GUI
+  hosts: all
+  become: true
+  vars:
+    user_home: "/home/vagrant"
+    visualizer_version: "1.1.3"
+    visualizer_gui_version: "0.1.0"
+    pipx_bin_path: "{{ user_home }}/.local/bin"
+    pipx_venv_gui_path: "{{ user_home }}/.local/share/pipx/venvs/precice-config-visualizer-gui/share"
+
+  tasks:
+    - name: Install CLI dependencies (graphviz)
+      apt:
+        name: graphviz
+        state: present
+        update_cache: yes
+
+    - name: Install system dependencies for GUI and PyGObject
+      apt:
+        name:
+          - build-essential
+          - pkg-config
+          - python3-dev
+          - libcairo2-dev
+          - libgirepository1.0-dev
+          - libglib2.0-dev
+          - libffi-dev                    # ✅ REQUIRED FOR PyGObject
+          - gir1.2-gtk-3.0
+          - python3-gi
+          - python3-cairo
+          - meson
+          - ninja-build
+        state: present
+        update_cache: yes
+
+    - name: Ensure pipx is installed
+      apt:
+        name: pipx
+        state: present
+
+    - name: Install preCICE Config Visualizer CLI
+      become: false
+      shell: |
+        pipx install --force precice-config-visualizer=={{ visualizer_version }}
+      environment:
+        PATH: "{{ pipx_bin_path }}:{{ ansible_env.PATH }}"
+      args:
+        executable: /bin/bash
+
+    - name: Install preCICE Config Visualizer GUI
+      become: false
+      shell: |
+        pipx install --force precice-config-visualizer-gui=={{ visualizer_gui_version }}
+      environment:
+        PATH: "{{ pipx_bin_path }}:{{ ansible_env.PATH }}"
+      args:
+        executable: /bin/bash
+
+    - name: Add pipx bin path to PATH in .bashrc
+      become: false
+      lineinfile:
+        path: "{{ user_home }}/.bashrc"
+        line: 'export PATH="{{ pipx_bin_path }}:${PATH}"'
+        insertafter: EOF
+
+    - name: Create user application and icon directories
+      become: false
+      file:
+        path: "{{ item }}"
+        state: directory
+        mode: '0755'
+      loop:
+        - "{{ user_home }}/.local/share/applications"
+        - "{{ user_home }}/.local/share/icons"
+
+    - name: Copy GUI desktop file
+      become: false
+      copy:
+        src: "{{ pipx_venv_gui_path }}/applications/org.precice.config_visualizer.desktop"
+        dest: "{{ user_home }}/.local/share/applications/org.precice.config_visualizer.desktop"
+        remote_src: yes
+        mode: '0644'
+
+    - name: Copy GUI icon file
+      become: false
+      copy:
+        src: "{{ pipx_venv_gui_path }}/icons/hicolor/scalable/apps/org.precice.config_visualizer.svg"
+        dest: "{{ user_home }}/.local/share/icons/org.precice.config_visualizer.svg"
+        remote_src: yes
+        mode: '0644'

--- a/ansible/playbooks/install-dealii.yml
+++ b/ansible/playbooks/install-dealii.yml
@@ -1,0 +1,52 @@
+---
+- name: Install deal.II and the preCICE deal.II adapter
+  hosts: all
+  become: true
+
+  vars:
+    adapter_repo_url: "https://github.com/precice/dealii-adapter.git"
+
+  tasks:
+    - name: Update apt cache
+      apt:
+        update_cache: yes
+
+    - name: Install libdeal.ii-dev package
+      apt:
+        name: libdeal.ii-dev
+        state: present
+
+    - name: Set adapter path using actual user directory
+      set_fact:
+        adapter_path: "{{ lookup('env', 'HOME') }}/dealii-adapter"
+      become: false
+
+    - name: Debug adapter path
+      become: false
+      debug:
+        msg: "Adapter will be cloned to: {{ adapter_path }}"
+
+    - name: Clone deal.II adapter repo if not present
+      become: false
+      git:
+        repo: "{{ adapter_repo_url }}"
+        dest: "{{ adapter_path }}"
+        version: master
+        depth: 1
+        update: yes
+
+    - name: Build the deal.II adapter
+      become: false
+      shell: |
+        cmake .
+        make -j $(nproc)
+      args:
+        chdir: "{{ adapter_path }}"
+        executable: /bin/bash
+
+    - name: Add deal.II adapter path to PATH in .bashrc
+      become: false
+      lineinfile:
+        path: "{{ lookup('env', 'HOME') }}/.bashrc"
+        line: 'export PATH="{{ adapter_path }}:${PATH}"'
+        insertafter: EOF

--- a/ansible/playbooks/install-devel.yml
+++ b/ansible/playbooks/install-devel.yml
@@ -1,0 +1,19 @@
+- name: Set up development environment
+  hosts: all
+  become: true
+  tasks:
+    - name: Install development tools and editors
+      apt:
+        name:
+          - build-essential
+          - git
+          - cmake
+          - cmake-curses-gui
+          - cargo
+          - nano
+          - vim
+          - gedit
+          - meld
+          - ipython3
+        state: present
+        update_cache: yes

--- a/ansible/playbooks/install-dune.yml
+++ b/ansible/playbooks/install-dune.yml
@@ -1,0 +1,117 @@
+---
+- name: Install DUNE, DuMux, and preCICE adapters
+  hosts: all
+  gather_facts: yes
+  vars:
+    home_dir: "{{ ansible_env.HOME }}"
+    dune_dir: "{{ home_dir }}/dune-dumux"
+    dune_modules:
+      - { name: dune-common, url: https://gitlab.dune-project.org/core/dune-common.git, branch: v2.9.1 }
+      - { name: dune-istl, url: https://gitlab.dune-project.org/core/dune-istl.git, branch: v2.9.1 }
+      - { name: dune-localfunctions, url: https://gitlab.dune-project.org/core/dune-localfunctions.git, branch: v2.9.1 }
+      - { name: dune-grid, url: https://gitlab.dune-project.org/core/dune-grid.git, branch: v2.9.1 }
+      - { name: dune-geometry, url: https://gitlab.dune-project.org/core/dune-geometry.git, branch: v2.9.1 }
+      - { name: dune-foamgrid, url: https://gitlab.dune-project.org/extensions/dune-foamgrid.git, branch: 2.9.1 }
+      - { name: dune-functions, url: https://gitlab.dune-project.org/staging/dune-functions.git, branch: v2.9.1 }
+      - { name: dune-typetree, url: https://gitlab.dune-project.org/staging/dune-typetree.git, branch: v2.9.1 }
+      - { name: dune-uggrid, url: https://gitlab.dune-project.org/staging/dune-uggrid.git, branch: v2.9.1 }
+    elastodynamics_repo: "https://github.com/maxfirmbach/dune-elastodynamics.git"
+    dune_adapter_repo: "https://github.com/precice/dune-adapter.git"
+    dumux_repo: "https://git.iws.uni-stuttgart.de/dumux-repositories/dumux.git"
+    dumux_adapter_repo: "https://github.com/precice/dumux-adapter.git"
+
+  tasks:
+    - name: Install git if not present
+      become: true
+      apt:
+        name: git
+        state: present
+        update_cache: yes
+
+    - name: Ensure dune-dumux directory exists
+      file:
+        path: "{{ dune_dir }}"
+        state: directory
+
+    - name: Clone core DUNE modules
+      git:
+        repo: "{{ item.url }}"
+        dest: "{{ dune_dir }}/{{ item.name }}"
+        version: "{{ item.branch }}"
+        depth: 1
+        update: yes
+      loop: "{{ dune_modules }}"
+
+    - name: Clone dune-elastodynamics
+      git:
+        repo: "{{ elastodynamics_repo }}"
+        dest: "{{ dune_dir }}/dune-elastodynamics"
+        version: master
+        depth: 1
+        update: yes
+
+    - name: Pull latest dune-elastodynamics
+      shell: git pull
+      args:
+        chdir: "{{ dune_dir }}/dune-elastodynamics"
+
+    - name: Clone dune-adapter
+      git:
+        repo: "{{ dune_adapter_repo }}"
+        dest: "{{ dune_dir }}/dune-adapter"
+        version: main
+        depth: 1
+        update: yes
+
+    - name: Pull latest dune-adapter
+      shell: git pull
+      args:
+        chdir: "{{ dune_dir }}/dune-adapter/dune-precice"
+
+    - name: Build all DUNE modules with dunecontrol
+      shell: ./dune-common/bin/dunecontrol all
+      args:
+        chdir: "{{ dune_dir }}"
+
+    - name: Clone DuMux repository
+      git:
+        repo: "{{ dumux_repo }}"
+        dest: "{{ dune_dir }}/dumux"
+        version: releases/3.8
+        depth: 1
+        update: yes
+
+    - name: Build DuMux with dunecontrol
+      shell: |
+        CMAKE_FLAGS="$CMAKE_FLAGS -DCMAKE_DISABLE_FIND_PACKAGE_Kokkos=TRUE" ./dune-common/bin/dunecontrol --only=dumux all
+      args:
+        chdir: "{{ dune_dir }}"
+        executable: /bin/bash
+
+    - name: Clone DuMux adapter
+      git:
+        repo: "{{ dumux_adapter_repo }}"
+        dest: "{{ dune_dir }}/dumux-adapter"
+        version: v2.0.0
+        depth: 1
+        update: yes
+
+    - name: Build DuMux adapter with dunecontrol
+      shell: |
+        CMAKE_FLAGS="$CMAKE_FLAGS -DCMAKE_DISABLE_FIND_PACKAGE_Kokkos=TRUE" ./dune-common/bin/dunecontrol --only=dumux-precice all
+      args:
+        chdir: "{{ dune_dir }}"
+        executable: /bin/bash
+
+    - name: Add DUNE_CONTROL_PATH to .bashrc
+      lineinfile:
+        path: "{{ home_dir }}/.bashrc"
+        line: 'export DUNE_CONTROL_PATH="{{ dune_dir }}"'
+        insertafter: EOF
+
+    - name: Copy DUNE example to tutorials
+      copy:
+        src: "{{ dune_dir }}/dune-adapter/dune-precice-howto/build-cmake/examples/dune-perpendicular-flap"
+        dest: "{{ home_dir }}/tutorials/perpendicular-flap/solid-dune"
+        remote_src: yes
+        mode: '0755'

--- a/ansible/playbooks/install-fenics.yml
+++ b/ansible/playbooks/install-fenics.yml
@@ -1,0 +1,67 @@
+---
+- name: Install FEniCS and the FEniCS-preCICE adapter
+  hosts: all
+  become: true
+
+  vars:
+    distro_user: "{{ ansible_user_id }}"
+
+  tasks:
+    - name: Get actual user home directory (not root)
+      become: false
+      set_fact:
+        distro_user_home: "{{ lookup('env', 'HOME') }}"
+
+    - name: Set fenics venv path
+      set_fact:
+        fenics_venv_path: "{{ distro_user_home }}/python-venvs/fenicsprecice"
+
+    - name: Install software-properties-common for add-apt-repository
+      apt:
+        name: software-properties-common
+        state: present
+        update_cache: yes
+
+    - name: Add FEniCS APT repository
+      apt_repository:
+        repo: ppa:fenics-packages/fenics
+        state: present
+
+    - name: Update APT cache after adding FEniCS repo
+      apt:
+        update_cache: yes
+
+    - name: Install FEniCS without recommended packages
+      apt:
+        name: fenics
+        state: present
+        install_recommends: no
+
+    - name: Install Python venv module and pip
+      apt:
+        name:
+          - python3-venv
+          - python3-pip
+        state: present
+
+    - name: Ensure directory for virtual environments exists
+      become: false
+      file:
+        path: "{{ distro_user_home }}/python-venvs"
+        state: directory
+        mode: '0755'
+
+    - name: Create virtual environment for FEniCS-preCICE
+      become: false
+      command: python3 -m venv {{ fenics_venv_path }}
+      args:
+        creates: "{{ fenics_venv_path }}/bin/activate"
+
+    - name: Install fenicsprecice in virtual environment
+      become: false
+      shell: |
+        source {{ fenics_venv_path }}/bin/activate
+        pip install --upgrade pip
+        pip install fenicsprecice
+      args:
+        executable: /bin/bash

--- a/ansible/playbooks/install-fmiprecice.yml
+++ b/ansible/playbooks/install-fmiprecice.yml
@@ -1,0 +1,17 @@
+---
+- name: Install FMI-preCICE runner via pipx
+  hosts: all
+  become: true
+
+  tasks:
+    - name: Ensure pipx is installed
+      apt:
+        name: pipx
+        state: present
+        update_cache: yes
+
+    - name: Install fmiprecice using pipx
+      become: false
+      shell: pipx install fmiprecice
+      args:
+        executable: /bin/bash

--- a/ansible/playbooks/install-julia-bindings.yml
+++ b/ansible/playbooks/install-julia-bindings.yml
@@ -1,0 +1,47 @@
+---
+- name: Install Julia and PreCICE Julia bindings
+  hosts: all
+  become: true
+
+  tasks:
+    - name: Install python3-venv and pip
+      apt:
+        name:
+          - python3-venv
+          - python3-pip
+        state: present
+        update_cache: yes
+
+- name: Configure Julia environment as normal user
+  hosts: all
+  become: false
+  vars:
+    julia_venv_base: "{{ ansible_env.HOME }}/python-venvs"
+    julia_venv_path: "{{ julia_venv_base }}/julia"
+
+  tasks:
+    - name: Ensure directory for virtual environments exists
+      file:
+        path: "{{ julia_venv_base }}"
+        state: directory
+        mode: '0755'
+
+    - name: Create virtual environment for Julia
+      command: python3 -m venv {{ julia_venv_path }}
+      args:
+        creates: "{{ julia_venv_path }}/bin/activate"
+
+    - name: Install jill and Julia via jill
+      shell: |
+        source {{ julia_venv_path }}/bin/activate
+        pip install --upgrade pip
+        pip install jill
+        jill install --confirm
+      args:
+        executable: /bin/bash
+
+    - name: Install PreCICE Julia bindings
+      shell: |
+        ~/.local/bin/julia -e 'using Pkg; Pkg.add("PreCICE")'
+      args:
+        executable: /bin/bash

--- a/ansible/playbooks/install-micro-manager.yml
+++ b/ansible/playbooks/install-micro-manager.yml
@@ -1,0 +1,17 @@
+---
+- name: Install micro-manager-preCICE via pipx
+  hosts: all
+  become: true
+
+  tasks:
+    - name: Ensure pipx is installed
+      apt:
+        name: pipx
+        state: present
+        update_cache: yes
+
+    - name: Install micro-manager-precice using pipx
+      become: false
+      shell: pipx install micro-manager-precice
+      args:
+        executable: /bin/bash

--- a/ansible/playbooks/install-openfoam.yml
+++ b/ansible/playbooks/install-openfoam.yml
@@ -1,0 +1,61 @@
+---
+- name: Install OpenFOAM system-wide
+  hosts: all
+  become: true
+
+  tasks:
+    - name: Add OpenFOAM signing key and repository
+      shell: wget -q -O - https://dl.openfoam.com/add-debian-repo.sh | bash
+      args:
+        executable: /bin/bash
+
+    - name: Install OpenFOAM v2312
+      apt:
+        name: openfoam2312-dev
+        state: present
+
+- name: Setup OpenFOAM-preCICE for local user
+  hosts: all
+  become: false
+  vars:
+    openfoam_version: openfoam2312
+
+  tasks:
+    - name: Set actual user home
+      ansible.builtin.set_fact:
+        actual_home: "{{ ansible_env.HOME }}"
+
+    - name: Enable OpenFOAM by default in .bashrc
+      lineinfile:
+        path: "{{ actual_home }}/.bashrc"
+        line: ". /usr/lib/openfoam/{{ openfoam_version }}/etc/bashrc"
+        create: yes
+
+    - name: Clone OpenFOAM-preCICE adapter repository
+      git:
+        repo: https://github.com/precice/openfoam-adapter.git
+        dest: "{{ actual_home }}/openfoam-adapter"
+        version: master
+        depth: 1
+        update: yes
+
+    - name: Build OpenFOAM-preCICE adapter
+      shell: |
+        source /usr/lib/openfoam/{{ openfoam_version }}/etc/bashrc
+        ./Allclean
+        ./Allwmake
+      args:
+        chdir: "{{ actual_home }}/openfoam-adapter"
+        executable: /bin/bash
+      environment:
+        FOAM_INST_DIR: /usr/lib/openfoam
+
+    - name: Build OpenFOAM solver in tutorial
+      shell: |
+        source /usr/lib/openfoam/{{ openfoam_version }}/etc/bashrc
+        wmake
+      args:
+        chdir: "{{ actual_home }}/tutorials/partitioned-heat-conduction/solver-openfoam"
+        executable: /bin/bash
+      environment:
+        FOAM_INST_DIR: /usr/lib/openfoam

--- a/ansible/playbooks/install-paraview.yml
+++ b/ansible/playbooks/install-paraview.yml
@@ -1,0 +1,12 @@
+---
+- name: Install ParaView without recommends
+  hosts: all
+  become: true
+
+  tasks:
+    - name: Install ParaView without recommended packages
+      apt:
+        name: paraview
+        state: present
+        install_recommends: no
+

--- a/ansible/playbooks/install-precice.yml
+++ b/ansible/playbooks/install-precice.yml
@@ -1,0 +1,191 @@
+---
+- name: Install preCICE and related tutorials
+  hosts: all
+  become: true
+  vars:
+    user_home: "/home/vagrant"
+    precice_repo: "https://github.com/precice/precice.git"
+    tutorials_repo: "https://github.com/precice/tutorials.git"
+    fortran_module_repo: "https://github.com/precice/fortran-module.git"
+    python_bindings_repo: "https://github.com/precice/python-bindings.git"
+    precice_path: "{{ user_home }}/precice"
+    venv_path: "{{ user_home }}/python-venvs/pyprecice"
+
+  tasks:
+    - name: Install preCICE build dependencies
+      apt:
+        name:
+          - cmake
+          - libeigen3-dev
+          - libxml2-dev
+          - libboost-all-dev
+          - petsc-dev
+          - python3-dev
+          - python3-numpy
+        state: present
+        update_cache: yes
+
+    - name: Clone preCICE repo if not present
+      git:
+        repo: "{{ precice_repo }}"
+        dest: "{{ precice_path }}"
+        version: main
+        depth: 1
+        update: yes
+      become: false
+
+    - name: Build and package preCICE
+      become: false
+      shell: |
+        mkdir -p build && cd build
+        cmake -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_SHARED_LIBS=ON \
+              -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+              -DPRECICE_RELEASE_WITH_DEBUG_LOG=ON -DBUILD_TESTING=OFF -Wno-dev ..
+        make -j $(nproc)
+        rm -fv ./*.deb && make package
+        sudo apt-get install -y ./libprecice*_*.deb
+        rm -rfv ./*.deb ./*.tar.gz _CPack_Packages
+      args:
+        chdir: "{{ precice_path }}"
+        executable: /bin/bash
+
+    - name: Copy examples from /usr/share
+      copy:
+        remote_src: true
+        src: /usr/share/precice/examples/
+        dest: "{{ precice_path }}-examples"
+        owner: vagrant
+        group: vagrant
+        mode: preserve
+
+    - name: Build solverdummies (C, C++, Fortran)
+      shell: |
+        cd solverdummies
+        for d in c cpp fortran; do
+          cd $d && cmake . && make && cd ..
+        done
+      args:
+        chdir: "{{ precice_path }}-examples"
+        executable: /bin/bash
+      become: false
+
+    - name: Clone and build fortran-module
+      git:
+        repo: "{{ fortran_module_repo }}"
+        dest: "{{ precice_path }}-examples/solverdummies/fortran-module"
+        depth: 1
+        update: yes
+      become: false
+
+    - name: Build fortran-module examples
+      shell: |
+        make
+        cd examples/solverdummy && make
+      args:
+        chdir: "{{ precice_path }}-examples/solverdummies/fortran-module"
+        executable: /bin/bash
+      become: false
+
+    - name: Clone tutorials if not present
+      git:
+        repo: "{{ tutorials_repo }}"
+        dest: "{{ user_home }}/tutorials"
+        depth: 1
+        update: yes
+      become: false
+
+    - name: Ensure Desktop directory exists
+      file:
+        path: "{{ user_home }}/Desktop"
+        state: directory
+        mode: '0755'
+      become: false
+
+    - name: Remove existing Desktop/tutorials if any
+      file:
+        path: "{{ user_home }}/Desktop/tutorials"
+        state: absent
+      become: false
+
+    - name: Link tutorials to Desktop
+      file:
+        src: "{{ user_home }}/tutorials"
+        dest: "{{ user_home }}/Desktop/tutorials"
+        state: link
+      become: false
+
+    - name: Build quickstart tutorial
+      shell: |
+        cmake . && make
+      args:
+        chdir: "{{ user_home }}/tutorials/quickstart/solid-cpp"
+        executable: /bin/bash
+      become: false
+
+    - name: Vendor Rust dependencies for elastic-tube-1d
+      shell: |
+        mkdir -p .cargo && cargo vendor > .cargo/config.toml
+      args:
+        chdir: "{{ item }}"
+        executable: /bin/bash
+      loop:
+        - "{{ user_home }}/tutorials/elastic-tube-1d/solid-rust"
+        - "{{ user_home }}/tutorials/elastic-tube-1d/fluid-rust"
+      become: false
+
+    - name: Run mesh download script for heat exchanger
+      shell: ./download-meshes.sh
+      args:
+        chdir: "{{ user_home }}/tutorials/heat-exchanger"
+        executable: /bin/bash
+      become: false
+
+    - name: Install gnuplot
+      apt:
+        name: gnuplot
+        state: present
+
+    - name: Install pip and venv
+      apt:
+        name:
+          - python3-pip
+          - python3-venv
+        state: present
+
+    - name: Create Python venv for pyprecice
+      become: false
+      command: python3 -m venv {{ venv_path }}
+      args:
+        creates: "{{ venv_path }}/bin/activate"
+
+    - name: Install pyprecice in venv
+      become: false
+      shell: |
+        source {{ venv_path }}/bin/activate
+        pip install --upgrade pip
+        pip install pyprecice
+      args:
+        executable: /bin/bash
+
+    - name: Clone Python bindings repo and copy solverdummy
+      git:
+        repo: "{{ python_bindings_repo }}"
+        dest: "{{ user_home }}/python-bindings"
+        depth: 1
+        update: yes
+      become: false
+
+    - name: Copy python solverdummy example
+      copy:
+        src: "{{ user_home }}/python-bindings/examples/solverdummy"
+        dest: "{{ precice_path }}-examples/solverdummies/python"
+        remote_src: yes
+        owner: vagrant
+        group: vagrant
+      become: false
+
+    - name: Remove python-bindings folder
+      file:
+        path: "{{ user_home }}/python-bindings"
+        state: absent
+      become: false

--- a/ansible/playbooks/install-su2.yml
+++ b/ansible/playbooks/install-su2.yml
@@ -1,0 +1,93 @@
+- name: Install SU2 and SU2-preCICE adapter
+  hosts: all
+  become: true
+
+  vars:
+    su2_version: "7.5.1"
+    su2_tar: "v{{ su2_version }}.tar.gz"
+    su2_dir: "SU2-{{ su2_version }}"
+    su2_adapter_repo: "https://github.com/precice/su2-adapter.git"
+
+  tasks:
+    - name: Create Python venv for SU2 adapter
+      ansible.builtin.shell: python3 -m venv ~/python-venvs/su2precice
+      args:
+        executable: /bin/bash
+
+    - name: Activate venv and install pip dependencies
+      shell: |
+        source ~/python-venvs/su2precice/bin/activate
+        python -m pip install --upgrade pip
+        python -m pip install mpi4py setuptools
+      args:
+        executable: /bin/bash
+
+    - name: Install swig
+      apt:
+        name: swig
+        state: present
+
+    - name: Download SU2 {{ su2_version }}
+      get_url:
+        url: "https://github.com/su2code/SU2/archive/refs/tags/{{ su2_tar }}"
+        dest: "~/{{ su2_tar }}"
+
+    - name: Extract SU2
+      unarchive:
+        src: "~/{{ su2_tar }}"
+        dest: ~/
+        remote_src: yes
+
+    - name: Remove SU2 tarball
+      file:
+        path: "~/{{ su2_tar }}"
+        state: absent
+
+    - name: Create ~/.su2-bashrc with SU2 environment variables
+      copy:
+        dest: ~/.su2-bashrc
+        content: |
+          export SU2_HOME="${HOME}/{{ su2_dir }}"
+          export SU2_RUN="${SU2_HOME}/SU2_CFD"
+          export PATH="${SU2_RUN}/bin/:${HOME}/su2-adapter/run/:${PATH}"
+          export PYTHONPATH="${SU2_RUN}/bin/:${PYTHONPATH}"
+
+    - name: Source .su2-bashrc from .bashrc
+      lineinfile:
+        path: ~/.bashrc
+        line: ". ${HOME}/.su2-bashrc"
+        create: yes
+
+    - name: Clone SU2 adapter
+      git:
+        repo: "{{ su2_adapter_repo }}"
+        dest: ~/su2-adapter
+        version: master
+        depth: 1
+
+    - name: Install SU2 adapter
+      shell: |
+        source ~/.su2-bashrc
+        ./su2AdapterInstall
+      args:
+        chdir: ~/su2-adapter
+        executable: /bin/bash
+
+    - name: Fix missing header for Ubuntu 24.04 compatibility
+      lineinfile:
+        path: "~/{{ su2_dir }}/SU2_CFD/src/output/filewriter/CParaviewXMLFileWriter.cpp"
+        line: "#include <cstdint>"
+        insertafter: BOF
+
+    - name: Configure and build SU2 with Python wrapper
+      shell: |
+        source ~/.su2-bashrc
+        ./meson.py build -Denable-pywrapper=true --prefix="${SU2_RUN}" && ./ninja -C build install
+      args:
+        chdir: "~/{{ su2_dir }}"
+        executable: /bin/bash
+
+    - name: Remove libSU2Core.a to save space
+      file:
+        path: "~/{{ su2_dir }}/SU2_CFD/obj/libSU2Core.a"
+        state: absent

--- a/ansible/playbooks/install-vscode.yml
+++ b/ansible/playbooks/install-vscode.yml
@@ -1,0 +1,22 @@
+- name: Install Visual Studio Code and C++ extensions
+  hosts: all
+  become: true
+
+  tasks:
+    - name: Install VS Code via snap
+      snap:
+        name: code
+        classic: true
+        state: present
+
+    - name: Install C++ extension in VS Code
+      become: false
+      shell: code --install-extension ms-vscode.cpptools
+      args:
+        executable: /bin/bash
+
+    - name: Install GNU Global extension in VS Code
+      become: false
+      shell: code --install-extension austin.code-gnu-global
+      args:
+        executable: /bin/bash


### PR DESCRIPTION
# Convert provisioning shell scripts to reusable Ansible playbooks (#96)

### Summary

This pull request addresses [Issue #96: Reusable provisioning](https://github.com/precice/vm/issues/96) by converting selected shell-based provisioning scripts into reusable, idempotent **Ansible playbooks**. The goal is to support reproducible and flexible provisioning across Vagrant VMs, Live USB environments (Cubic), and Apptainer containers, using a common YAML-based infrastructure.

---

## ✔️ Converted Scripts

The following shell scripts were translated into Ansible playbooks:

| Original Shell Script               | Ansible Playbook                |
|-------------------------------------|----------------------------------|
| `install-aste.sh`                   | `install-aste.yml`              |
| `install-basics.sh`                 | `install-basics.yml`            |
| `install-calculix.sh`              | `install-calculix.yml`          |
| `install-code_aster.sh`            | `install-code_aster.yml`        |
| `install-config-visualizer.sh`     | `install-config-visualizer.yml` |
| `install-dealii.sh`                | `install-dealii.yml`            |
| `install-devel.sh`                 | `install-devel.yml`             |
| `install-dune.sh`                  | `install-dune.yml`              |
| `install-fenics.sh`                | `install-fenics.yml`            |
| `install-fmiprecice.sh`            | `install-fmiprecice.yml`        |
| `install-julia-bindings.sh`        | `install-julia-bindings.yml`    |
| `install-micro-manager.sh`         | `install-micro-manager.yml`     |
| `install-openfoam.sh`              | `install-openfoam.yml`          |
| `install-paraview.sh`              | `install-paraview.yml`          |
| `install-precice.sh`               | `install-precice.yml`           |
| `install-su2.sh`                   | `install-su2.yml`               |
| `install-vscode.sh`                | `install-vscode.yml`            |


---

## 🔧 Structure

```
ansible/
├── inventory.ini
├── playbooks/
│   ├── install-aste.yml
│   ├── install-basics.yml
│   ├── install-calculix.yml
│   ├── install-code_aster.yml
│   ├── install-config-visualizer.yml
│   ├── install-dealii.yml
│   ├── install-devel.yml
│   ├── install-dune.yml
│   ├── install-fenics.yml
│   ├── install-fmiprecice.yml
│   ├── install-julia-bindings.yml
│   ├── install-micro-manager.yml
│   ├── install-openfoam.yml
│   ├── install-paraview.yml
│   ├── install-precice.yml
│   ├── install-su2.yml
│   └── install-vscode.yml
└── README.md
```

- `inventory.ini`: for host targeting (currently local via Vagrant)
- `README.md`: describes usage, structure, and future goals

---

## 💡 Improvements Over Shell Scripts

- Declarative, **YAML-based structure** for easier maintenance
- **Idempotent** execution: safe to run multiple times
- More portable: can be reused across VM, container, and Live USB contexts
- Ready for **CI integration** and eventual support for **tags, roles, and variables**

---

## 🧪 Testing

- All playbooks tested on **Ubuntu 24.04** using Vagrant
- Verified with `--check` and `--diff` modes
- Manually validated installation outcomes for each component

---

## ✅ Issues and Fixes

### Issue 1: `/root` path inaccessible 
**File:** _All playbooks_  
**Fix:** Used `{{ lookup('env', 'HOME') }}` to dynamically get the current user’s home directory.



### Issue 2: Permission denied when creating `/root/python-venvs`  
**File:** `install-fenics.yml`, `install-julia-bindings.yml`  
**Fix:** Used `become: false` for tasks that create or access user-level directories such as virtual environments.


### Issue 3: Attempt to write to `/root/.bashrc`  
**File:** `install-openfoam.yml`  
**Fix:** Ensured `.bashrc` modifications target the correct non-root user’s home directory using `{{ user_home }}/.bashrc`.


### Issue 4: `install-dune.yml` tried writing to `/root/dune-dumux`  
**File:** `install-dune.yml`  
**Fix:** Used user-local directory based on `{{ user_home }}` and ensured proper `become` settings.



### Issue 5: `install-fenics.yml` failed on virtualenv creation  
**File:** `install-fenics.yml`  
**Fix:** Corrected permissions by ensuring virtual environment creation uses `become: false` and the right `user_home`.



### Issue 6: `install-julia-bindings.yml` failed at `/root/python-venvs`  
**File:** `install-julia-bindings.yml`  
**Fix:** Fixed path using dynamic home directory and ran venv and pip commands without `become`.



### Issue 7: `install-openfoam.yml` failed due to the wrong tutorial directory  
**File:** `install-openfoam.yml`  
**Fix:** Updated tutorial path using `{{ user_home }}/tutorials/...` instead of `~/...` or `/root/...`.


### Issue 8: `.bashrc` not writable by current user  
**File:** `install-openfoam.yml`, `install-aste.yml`  
**Fix:** Ensured tasks modifying `.bashrc` run without `become` and use the actual user’s home directory.


### Issue 9: `.bashrc` edit failed silently under root context  
**File:** `install-aste.yml`  
**Fix:** Used `lineinfile` module with correct user path and `become: false`.

### Issue 10: `install-code_aster.yml` has unresolved issues with installation
**File:** `install-code_aster.yml`  
**Fix:** No Fix Yet.

---

## Suggestions and Concerns for Ansible Playbook Refactoring

### 1. Use `become: false` for User-Space Actions

**Concern:** Tasks like creating virtual environments or modifying user `.bashrc` should run under the actual user context, not root.

**Suggestion:** Always explicitly set `become: false` for such tasks to avoid permission errors or modifications to `/root`.



### 2. Ensure Directories Exist Before Writing

**Concern:** Tasks that write to paths like `~/python-venvs/foo` can fail if the base directory doesn't exist.

**Suggestion:** Add `file` tasks to ensure directories exist with correct ownership before accessing them.


### 3. Avoid Appending Duplicate Lines to `.bashrc`

**Concern:** Repeated playbook runs can duplicate `export` lines in `.bashrc`.

**Suggestion:** Use `regexp` with `lineinfile` to match and replace lines safely instead of blindly appending with `insertafter: EOF`.



### 4. Use `chdir` for Directory Changes

**Concern:** Inline `cd` commands in `shell` can fail silently or be harder to debug.

**Suggestion:** Use Ansible's `chdir` parameter to set working directories cleanly for `shell` or `command` tasks.



### 5. Consistent Use of `user_home` Variable

**Concern:** Hardcoding paths like `/home/vagrant` reduces portability.

**Suggestion:** Use `lookup('env', 'HOME')` or `ansible_env.HOME` as a variable (`user_home`) across playbooks for user-path operations.



### 6. Use `creates:` for Idempotency in Virtualenv Creation

**Concern:** Without `creates:`, a playbook may recreate or overwrite existing environments.

**Suggestion:** Use `creates: "{{ path }}/bin/activate"` to make tasks idempotent.



### 7. Avoid Running User Shell Configurations as Root

**Concern:** Tasks that append to `.bashrc` or clone to `~/` may default to `/root/` if `become: true` is active.

**Suggestion:** Use `become: false` when working on user-specific files like `.bashrc`, Python virtual environments, or home directories.



### 8. Ensure Correct Permissions When Mixing `become: true` and `false`

**Concern:** Switching between elevated and non-elevated contexts can cause permission conflicts.

**Suggestion:** Always check ownership and permissions, especially when files are created with `become: true` and accessed without it later.



Closes #96
