### PR TITLE
Remove unneeded .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,0 @@
-*.so filter=lfs diff=lfs merge=lfs -text
-*.tar.gz filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
This was added in the context of tracking some pre-built dependencies on Git LFS.
We no longer need it.

I will then also disable Git LFS in the repository.