### PR TITLE
Add an install-training-python.sh

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -60,6 +60,7 @@ Vagrant.configure("2") do |config|
   # config.vm.provision "shell", path: "provisioning/install-aste.sh", privileged: false
 
   # Install additional packages for training
+  config.vm.provision "shell", path: "provisioning/install-training-python.sh", privileged: false
   config.vm.provision "shell", path: "provisioning/install-training-fsi.sh", privileged: false
 
   # Install further packages from the preCICE Distribution

--- a/provisioning/install-precice.sh
+++ b/provisioning/install-precice.sh
@@ -58,9 +58,6 @@ source ~/python-venvs/pyprecice/bin/activate
 
 python -m pip install pyprecice
 
-# Additional python packages -> Should go into tutorials venvs
-# pip3 install --user pandas matplotlib polars # Needed for the post-processing scripts
-
 deactivate
 
 # Get the Python solverdummy into the examples

--- a/provisioning/install-training-fsi.sh
+++ b/provisioning/install-training-fsi.sh
@@ -2,9 +2,8 @@
 set -ex
 
 # Additional packages for the FSI training module
-python -m venv ~/python-venvs/training-fsi
 # shellcheck disable=SC1090 # We don't need to lint this external script
-source ~/python-venvs/training-fsi/bin/activate
+source ~/python-venvs/pyprecice/bin/activate
 python -m pip install pyfoam
 deactivate
 pipx install ccx2paraview

--- a/provisioning/install-training-python.sh
+++ b/provisioning/install-training-python.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -ex
+
+# shellcheck disable=SC1090 # We don't need to lint this external script
+source ~/python-venvs/pyprecice/bin/activate
+pip3 install --user matplotlib pandas polars
+pip3 install --user nutils
+deactivate

--- a/provisioning/post-install.sh
+++ b/provisioning/post-install.sh
@@ -14,4 +14,8 @@ chmod +x ~/Desktop/terminator.desktop
     echo "gsettings set org.gnome.desktop.screensaver lock-enabled false"
 } >> ~/.bashrc
 
-echo "source ${HOME}/.alias" >>~/.bashrc
+# Add aliases and enable the python venv by default
+{
+    echo "source ${HOME}/.alias"
+    echo "source ${HOME}/python-venvs/pyprecice/bin/activate"
+} >> ~/.bashrc


### PR DESCRIPTION
This PR:

- Activates the `pyprecice` venv by default
- Replaces the `training-fsi` venv with the `pyprecice` venv
- Installs additional packages needed for the training (nutils, matplotlib, pandas, polars)