### PR TITLE
Port to Ubuntu 26.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,11 @@ This box is based on the [bento/ubuntu-24.04](https://github.com/chef/bento) bas
 - preCICE latest from the master branch (built in release-with-debug-info mode)
 - preCICE config visualizer with its GUI (PyPI, latest)
 - preCICE Python bindings (PyPI, latest), under `~/python-venvs/pyprecice`.
+- preCICE Rust bindings (Cargo, latest)
 - preCICE Julia bindings (Pkg, latest)
 - preCICE FMI Runner (PyPI, latest)
 - preCICE Micro Manager (PyPI, latest)
+- ASTE (Git, develop branch)
 - OpenFOAM v2512 and the OpenFOAM-preCICE adapter (Git, develop branch)
 - deal.II 9.5 from the official PPA and the deal.II-preCICE adapter (Git, develop branch)
 - CalculiX 2.20 from source and the CalculiX-preCICE adapter (Git, develop branch)
@@ -75,8 +77,6 @@ At the end, it cleans up all object files and the APT cache (see `cleanup.sh`).
 
 ## What should be there but is currently not included?
 
-- ASTE (Git, develop branch) -> Cannot build using the VTK packages bundled in Ubuntu 24.04. Will enable again in the next upgrade.
-- preCICE Rust bindings (Cargo, latest) -> Cargo too old in Ubuntu 24.04.
 - code_aster 14.6 and the code_aster-preCICE adapter -> Adapter currently unmaintained.
 
 ## Troubleshooting

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Ready-to-use boxes are available on [Vagrant Cloud](https://app.vagrantup.com/pr
 **Note:** If you only want to directly get a pre-built box, look at the [documentation](https://www.precice.org/installation-vm.html).
 
 1. Get a Virtual Machine provider, such as [VirtualBox](https://www.virtualbox.org/)
-2. Get [Vagrant](https://www.vagrantup.com/)
+2. Get [Vagrant](https://www.vagrantup.com/) and the [vagrant-reload plugin](https://github.com/aidanns/vagrant-reload)
 3. Go to the root folder of this repository and start with `vagrant up`.
 4. Be patient. Vagrant will now setup your virtual machine. You don't have to do anything and your terminal will be very busy.
 5. After the provisioning finishes, restart the machine with `vagrant reload` to get a full GUI

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -54,7 +54,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision "shell", path: "provisioning/install-micro-manager.sh", privileged: false
   config.vm.provision "shell", path: "provisioning/install-paraview.sh", privileged: false
 
-  # NOTE: In Ubuntu 24.04, building ASTE will succeed, but running the aste-turbine tutorial, for example, will break.
+  # NOTE: On Ubuntu 24.04, building ASTE will succeed, but running the aste-turbine tutorial, for example, will break.
   # See the documentation: https://precice.org/tooling-aste.html#dependencies
   config.vm.provision "shell", path: "provisioning/install-aste.sh", privileged: false
 
@@ -68,11 +68,10 @@ Vagrant.configure("2") do |config|
   config.vm.provision "shell", path: "provisioning/install-dune.sh", privileged: false
   config.vm.provision "shell", path: "provisioning/install-su2.sh", privileged: false
   
-  # Rust tutorials incompatible with cargo 1.75.0, shipped with Ubuntu 24.04
-  # Error: The package requires the Cargo feature called `edition2024`, but that feature is not stabilized in this version of Cargo (1.75.0).
-  # config.vm.provision "shell", path: "provisioning/install-rust-bindings.sh", privileged: false
+  # NOTE: On Ubuntu 24.04, the Rust cargo installation is too old.
+  config.vm.provision "shell", path: "provisioning/install-rust-bindings.sh", privileged: false
   
-  # code_aster does not build on Ubuntu 22.04/24.04 due to multiple issues: https://github.com/precice/code_aster-adapter/issues/26
+  # code_aster does not build on Ubuntu 22.04 or later due to multiple issues: https://github.com/precice/code_aster-adapter/issues/26
   # config.vm.provision "shell", path: "provisioning/install-code_aster.sh", privileged: false
 
   # Post-installation steps

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,7 +6,7 @@ Vagrant.configure("2") do |config|
   # This allows us to create performance oriented images for Linux (libvirt) and Windows (hyperv).
   # However, it does not build: https://github.com/precice/vm/issues/83
   # config.vm.box = "generic/ubuntu2004"
-  config.vm.box = "bento/ubuntu-24.04"
+  config.vm.box = "bento/ubuntu-26.04"
 
   # We don't want the box to automatically update every time it starts.
   # We can instead handle updates internally, without destroying the machine.
@@ -18,9 +18,9 @@ Vagrant.configure("2") do |config|
     # Display the VirtualBox GUI when booting the machine
     vb.gui = true
     # Number of cores
-    vb.cpus = 2
+    vb.cpus = 4
     # Customize the amount of memory on the VM:
-    vb.memory = "2048"
+    vb.memory = "4096"
     # Video memory (the default may be too low for some applications)
     vb.customize ["modifyvm", :id, "--vram", "64"]
     # The default graphics controller is VboxSVGA. This seems to cause issues with auto-scaling.
@@ -32,8 +32,8 @@ Vagrant.configure("2") do |config|
   config.vm.provider :libvirt do |lv|
     lv.forward_ssh_port = true
     lv.title = "preCICE-VM"
-    lv.cpus = 2
-    lv.memory = 2048
+    lv.cpus = 4
+    lv.memory = 4096
   end
 
   # Install a desktop environment and basic tools
@@ -56,8 +56,7 @@ Vagrant.configure("2") do |config|
 
   # NOTE: In Ubuntu 24.04, building ASTE will succeed, but running the aste-turbine tutorial, for example, will break.
   # See the documentation: https://precice.org/tooling-aste.html#dependencies
-  # Disabling until the upgrade to Ubuntu 26.04
-  # config.vm.provision "shell", path: "provisioning/install-aste.sh", privileged: false
+  config.vm.provision "shell", path: "provisioning/install-aste.sh", privileged: false
 
   # Install additional packages for training
   config.vm.provision "shell", path: "provisioning/install-training-python.sh", privileged: false

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -39,6 +39,9 @@ Vagrant.configure("2") do |config|
   # Install a desktop environment and basic tools
   config.vm.provision "shell", path: "provisioning/install-basics.sh", privileged: false
   
+  # Reload the VM (requires https://github.com/aidanns/vagrant-reload)
+  config.vm.provision :reload
+
   # Install common development tools
   config.vm.provision "shell", path: "provisioning/install-devel.sh", privileged: false
   

--- a/provisioning/install-basics.sh
+++ b/provisioning/install-basics.sh
@@ -11,7 +11,7 @@ sudo apt-get upgrade -qy
 
 # Install the Xfce desktop environment and basic applications
 sudo apt-get install -y xubuntu-core
-sudo apt-get install -y thunar xfce4-terminal terminator bash-completion tree atril firefox firefox-locale-en baobab catfish
+sudo apt-get install -y thunar xfce4-terminal terminator bash-completion tree atril firefox firefox-locale-en baobab catfish file-roller
 sudo apt-get install -y python3-dev pipx python-is-python3 python3-venv python3-pip python3-pybind11
 
 # Setup auto-login for the graphical session

--- a/provisioning/install-dune.sh
+++ b/provisioning/install-dune.sh
@@ -51,6 +51,8 @@ fi
 (
     cd dune-elastodynamics
     git pull
+    # Apply patch https://github.com/maxfirmbach/dune-elastodynamics/pull/2
+    sed -i 's/VERSION 3.1/VERSION 3.13/g' CMakeLists.txt
 )
 
 # Get the plain DUNE-preCICE adapter

--- a/provisioning/install-fenics.sh
+++ b/provisioning/install-fenics.sh
@@ -1,11 +1,8 @@
 #!/usr/bin/env bash
 set -ex
 
-# Install FEniCS from APT
-sudo apt-get install -y software-properties-common
-sudo add-apt-repository -y ppa:fenics-packages/fenics
 sudo apt-get -y update
-sudo apt-get -y install --no-install-recommends fenics
+sudo apt-get -y install fenics
 
 # Install the FEniCS-preCICE adapter from PIP
 # python -m venv ~/python-venvs/fenicsprecice

--- a/provisioning/install-paraview.sh
+++ b/provisioning/install-paraview.sh
@@ -2,3 +2,6 @@
 set -ex
 
 sudo apt-get install -y --no-install-recommends paraview
+
+# Workaround for https://bugs.launchpad.net/ubuntu/+source/paraview/+bug/2155064
+sudo apt-get install -y qt6-svg-plugins

--- a/provisioning/install-precice.sh
+++ b/provisioning/install-precice.sh
@@ -13,6 +13,10 @@ fi
 (
     cd precice
     git pull
+    
+    # Patch for Ubuntu 26.04, see https://github.com/precice/precice/commit/6a0be7aa64087f21740c566921e83e97e03e1067
+    sed -i 's/libxml2/libxml2-dev/g' cmake/CPackConfig.cmake
+
     mkdir -p build && cd build/
     cmake -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo -DPRECICE_RELEASE_WITH_DEBUG_LOG=ON -DBUILD_TESTING=OFF -Wno-dev ..
     make -j "$(nproc)"
@@ -42,9 +46,6 @@ if [ ! -d "tutorials/" ]; then
 fi
 (
     cd tutorials/quickstart/solid-cpp/ && cmake . && make
-)
-(
-    cd tutorials/heat-exchanger && ./download-meshes.sh
 )
 sudo apt-get -y install gnuplot # needed for watchpoint scripts of tutorials
 

--- a/provisioning/install-su2.sh
+++ b/provisioning/install-su2.sh
@@ -8,7 +8,7 @@ source ~/python-venvs/su2precice/bin/activate
 python -m pip install mpi4py setuptools # pyprecice is installed by the tutorials
 sudo apt-get -y install swig
 
-# Get SU2 7.5.1 from GitHub
+# Get SU2 from GitHub
 git clone --depth=1 --branch=v7.5.1 --recurse-submodules https://github.com/su2code/SU2.git
 
 # Add SU2 and the SU2 adapter to PATH and apply.
@@ -46,18 +46,7 @@ fi
     # See https://github.com/ninja-build/ninja/commit/9cf13cd1ecb7ae649394f4133d121a01e191560b
     sed -i 's/pipes/shlex/g' externals/ninja/configure.py
 
-    # Disable CGNS with -Denable-cgns=false. Workaround for:
-    # default: FAILED: externals/cgns/libcgns.a.p/adf_ADF_internals.c.o
-    # default: cc -Iexternals/cgns/libcgns.a.p -Iexternals/cgns -I../externals/cgns -Iexternals/cgns/hdf5 -I../externals/cgns/hdf5 -I/usr/lib/x86_64-linux-gnu/openmpi/include -I/usr/lib/x86_64-linux-gnu/openmpi/include/openmpi -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -std=c99 -O3 -fPIC -Wno-unused-result -Wno-unused-parameter -Wno-unused-variable -Wno-unused-but-set-variable -Wno-sign-compare -Wno-error=unused-function -Wno-pedantic -Wno-error=stringop-truncation -Wno-stringop-truncation -Wno-error=absolute-value -Wno-error=class-memaccess -MD -MQ externals/cgns/libcgns.a.p/adf_ADF_internals.c.o -MF externals/cgns/libcgns.a.p/adf_ADF_internals.c.o.d -o externals/cgns/libcgns.a.p/adf_ADF_internals.c.o -c ../externals/cgns/adf/ADF_internals.c
-    # default: ../externals/cgns/adf/ADF_internals.c: In function ‘ADFI_open_file’:
-    # default: ../externals/cgns/adf/ADF_internals.c:194:17: error: implicit declaration of function ‘fileno’ [-Wimplicit-function-declaration]
-    # default:   194 | # define FILENO fileno
-    # default:       |                 ^~~~~~
-    # default: ../externals/cgns/adf/ADF_internals.c:5531:32: note: in expansion of macro ‘FILENO’
-    # default:  5531 |    f_ret = ftmp == NULL ? -1 : FILENO(ftmp);
-    # default:       |                                ^~~~~~
-    #
-    # Also set -Denable-tecio=false, as it is not needed, to save space.
+    # Disable unnecessary dependencies to save space and to workaround an issue that CGNS does not build.
     ./meson.py build -Denable-pywrapper=true -Denable-cgns=false -Denable-tecio=false --prefix="${SU2_RUN}" &&\
     ./ninja -C build install
 )

--- a/provisioning/install-su2.sh
+++ b/provisioning/install-su2.sh
@@ -9,14 +9,12 @@ python -m pip install mpi4py setuptools # pyprecice is installed by the tutorial
 sudo apt-get -y install swig
 
 # Get SU2 7.5.1 from GitHub
-wget --quiet  https://github.com/su2code/SU2/archive/refs/tags/v7.5.1.tar.gz
-tar -xzf v7.5.1.tar.gz
-rm -fv v7.5.1.tar.gz
+git clone --depth=1 --branch=v7.5.1 --recurse-submodules https://github.com/su2code/SU2.git
 
 # Add SU2 and the SU2 adapter to PATH and apply.
 # We first export to a separate script, so that we can load it here (non-interactive shell).
 {
-    echo "export SU2_HOME=\"\${HOME}/SU2-7.5.1\""
+    echo "export SU2_HOME=\"\${HOME}/SU2\""
     echo "export SU2_RUN=\"\${SU2_HOME}/SU2_CFD\""
     echo "export PATH=\"\${SU2_RUN}/bin/:\${HOME}/su2-adapter/run/:\${PATH}\""
     echo "export PYTHONPATH=\"\${SU2_RUN}/bin/:\${PYTHONPATH}\""
@@ -42,12 +40,29 @@ fi
     
     # Add a previously implied header (compatibility with Ubuntu 24.04)
     sed -i '1s/^/#include <cstdint>\n/' SU2_CFD/src/output/filewriter/CParaviewXMLFileWriter.cpp
+    sed -i '1s/^/#include <cstdint>\n/' SU2_CFD/src/SU2_CFD.cpp
 
-    ./meson.py build -Denable-pywrapper=true --prefix="${SU2_RUN}" &&\
+    # Replace pipes with shlex in Ninja configure (compatibility with Ubuntu 26.04 and Python >= 3.13)
+    # See https://github.com/ninja-build/ninja/commit/9cf13cd1ecb7ae649394f4133d121a01e191560b
+    sed -i 's/pipes/shlex/g' externals/ninja/configure.py
+
+    # Disable CGNS with -Denable-cgns=false. Workaround for:
+    # default: FAILED: externals/cgns/libcgns.a.p/adf_ADF_internals.c.o
+    # default: cc -Iexternals/cgns/libcgns.a.p -Iexternals/cgns -I../externals/cgns -Iexternals/cgns/hdf5 -I../externals/cgns/hdf5 -I/usr/lib/x86_64-linux-gnu/openmpi/include -I/usr/lib/x86_64-linux-gnu/openmpi/include/openmpi -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -std=c99 -O3 -fPIC -Wno-unused-result -Wno-unused-parameter -Wno-unused-variable -Wno-unused-but-set-variable -Wno-sign-compare -Wno-error=unused-function -Wno-pedantic -Wno-error=stringop-truncation -Wno-stringop-truncation -Wno-error=absolute-value -Wno-error=class-memaccess -MD -MQ externals/cgns/libcgns.a.p/adf_ADF_internals.c.o -MF externals/cgns/libcgns.a.p/adf_ADF_internals.c.o.d -o externals/cgns/libcgns.a.p/adf_ADF_internals.c.o -c ../externals/cgns/adf/ADF_internals.c
+    # default: ../externals/cgns/adf/ADF_internals.c: In function ‘ADFI_open_file’:
+    # default: ../externals/cgns/adf/ADF_internals.c:194:17: error: implicit declaration of function ‘fileno’ [-Wimplicit-function-declaration]
+    # default:   194 | # define FILENO fileno
+    # default:       |                 ^~~~~~
+    # default: ../externals/cgns/adf/ADF_internals.c:5531:32: note: in expansion of macro ‘FILENO’
+    # default:  5531 |    f_ret = ftmp == NULL ? -1 : FILENO(ftmp);
+    # default:       |                                ^~~~~~
+    #
+    # Also set -Denable-tecio=false, as it is not needed, to save space.
+    ./meson.py build -Denable-pywrapper=true -Denable-cgns=false -Denable-tecio=false --prefix="${SU2_RUN}" &&\
     ./ninja -C build install
 )
 
 # Remove the libSU2Core.a library to save space (approx. 500MB)
-rm -fv ~/SU2-7.5.1/SU2_CFD/obj/libSU2Core.a
+rm -fv ~/SU2/SU2_CFD/obj/libSU2Core.a
 
 deactivate

--- a/provisioning/install-training-fsi.sh
+++ b/provisioning/install-training-fsi.sh
@@ -11,7 +11,7 @@ pipx install ccx2paraview
 # FreeCAD AppImage from https://www.freecad.org/downloads.php (~780MB)
 (
   cd ~/Desktop
-  wget https://github.com/FreeCAD/FreeCAD/releases/download/1.1.1/FreeCAD_1.1.1-Linux-x86_64-py311.AppImage
+  wget --quiet https://github.com/FreeCAD/FreeCAD/releases/download/1.1.1/FreeCAD_1.1.1-Linux-x86_64-py311.AppImage
   mv FreeCAD_1.1.1-Linux-x86_64-py311.AppImage FreeCAD.AppImage
   chmod +x FreeCAD.AppImage
 )


### PR DESCRIPTION
This PR bumps the Ubuntu version to 26.04 (based on the [`bento/ubuntu-26.04`](https://portal.cloud.hashicorp.com/vagrant/discover/bento/ubuntu-26.04) box, first released yesterday) and enables the previously disabled components ASTE and Rust bindings (see #94).

It also changes the default number of cores to 4 and the RAM to 4GB.

Interesting in this release is that the [FEniCS PPA](https://launchpad.net/~fenics-packages/+archive/ubuntu/fenics) is not needed anymore: there are now both FEniCS legacy and FEniCSx packages on [Ubuntu Universe](https://packages.ubuntu.com/search?keywords=fenics&searchon=names&suite=resolute&section=all).

Notes:

- Since I am building custom Debian packages (to set the `production-audit` preset), and https://github.com/precice/precice/pull/2560 has not yet been released, I am applying the patch on top of `main`, to be able to say that the next distribution includes v3.4.1.
- SU2 needed a couple more patches for Ubuntu 26.04:
   - Ninja replaced the now deleted pipes library with shlex in https://github.com/ninja-build/ninja/commit/9cf13cd1ecb7ae649394f4133d121a01e191560b
   - To be able to patch the Ninja submodule, I replaced getting the archive with cloning the SU2 repository and its submodules.
   - I could not build CGNS, but it does not seem to be needed, so I disabled it, as well as TECIO.
- I disabled the pre-fetching of the heat-exchanger meshes, since this step is now integrated into the `run.sh` (see https://github.com/precice/tutorials/pull/805). This also saves a bit of space.

So far, I can confirm that the complete box builds. Proceeding with testing.

Issues:

- [x] Paraview has no icons on its buttons. (I also documented it on the [Kitware GitLab](https://gitlab.kitware.com/paraview/paraview/-/work_items/23298), and reported it on the [Ubuntu Bugzilla](https://bugs.launchpad.net/ubuntu/+source/paraview/+bug/2155064)). -> Was missing the `qt6-svg-plugins` package.
- [x] There is no "extract" option for `tar.gz` files in the context menu of the file manager. -> was missing the `thunar-archive-plugin` package.
- [ ] While trying to install `fenicsprecice`, it builds `scipy` from source, which takes a while. I could re-introduce the central venv. Some people suggest upgrading PIP first.
- [ ] Similar to Ubuntu 24.04, Desktop shortcuts require being set as trusted. See [some discussion](https://askubuntu.com/questions/1218954/desktop-files-allow-launching-set-this-via-cli). In any case, I could manually pre-set the launchers to trusted via the GUI, or restore a backup in subsequent builds.
- [ ] Not sure if this is new, but there is a `Failed to start vboxadd-service.service` message at boot, followed by a `Job systemd-networkd-wait-online.service/start running` that times out after ~2min.
- [ ] There is a similar one about GRUB (see screenshot)

<img width="1299" height="898" alt="Screenshot from 2026-06-10 20-56-38" src="https://github.com/user-attachments/assets/bb319af4-4212-4ab5-bc2c-657a5a3eba60" />
